### PR TITLE
 [design-system] fix: prefix 삭제(bee), border radius 추가 

### DIFF
--- a/apps/desserbee-web/src/stories/TailwindConfig.stories.tsx
+++ b/apps/desserbee-web/src/stories/TailwindConfig.stories.tsx
@@ -25,29 +25,22 @@ type Story = StoryObj<typeof meta>;
 // color
 export const Primary: Story = {
   args: {
-    className: "text-bee-primary ",
-    text: "적용: className='text-bee-primary'",
+    className: "text-primary ",
+    text: "적용: className='text-primary'",
   },
 };
 
 export const Secondary: Story = {
   args: {
-    className: "text-bee-secondary ",
-    text: "적용: className='text-bee-secondary'",
-  },
-};
-
-export const Accent: Story = {
-  args: {
-    className: "text-bee-accent ",
-    text: "적용: className='text-bee-accent'",
+    className: "text-secondary ",
+    text: "적용: className='text-secondary'",
   },
 };
 
 // 패딩 (spacing)
 export const Base_PX_PY: Story = {
   args: {
-    className: "text-bee-primary px-base py-base ",
+    className: "px-base py-base ",
     text: "적용: className='px-base py-base'",
   },
 };

--- a/packages/design-system/src/components/Tag.tsx
+++ b/packages/design-system/src/components/Tag.tsx
@@ -16,7 +16,7 @@ export function Tag({
     <button
       className={cn(
         "rounded-[100px] w-[104px] h-[37px] font-medium text-center text-lg text-nowrap",
-        isSelected && "bg-bee-primary text-white",
+        isSelected && "bg-primary text-white",
         !isSelected && "bg-white text-[#545454]"
       )}
       disabled={disabled}>

--- a/packages/design-system/src/stories/Test.stories.tsx
+++ b/packages/design-system/src/stories/Test.stories.tsx
@@ -13,6 +13,9 @@ const TailwindConfigTest = ({ className, text }: TailwindConfigestProps) => {
         {text}
         <br />
         <Button className={className}>shadcn 버튼</Button>
+        <div className={className + " w-40 h-36 bg-primary text-center"}>
+          border
+        </div>
       </div>
     </div>
   );
@@ -31,22 +34,29 @@ type Story = StoryObj<typeof meta>;
 // color
 export const Primary: Story = {
   args: {
-    className: "text-bee-primary ",
-    text: "className='text-bee-primary'",
+    className: "text-primary ",
+    text: "className='text-primary'",
   },
 };
 
 export const Secondary: Story = {
   args: {
-    className: "text-bee-secondary ",
-    text: "className='text-bee-secondary'",
+    className: "text-secondary ",
+    text: "className='text-secondary'",
   },
 };
 
 export const Disabled: Story = {
   args: {
-    className: "text-bee-disabled ",
-    text: "className='text-bee-disabled'",
+    className: "text--disabled ",
+    text: "className='text-disabled'",
+  },
+};
+
+export const BorderRadius: Story = {
+  args: {
+    className: "rounded-base",
+    text: "className='rounded-base'",
   },
 };
 

--- a/packages/tailwind-config/tailwind.config.ts
+++ b/packages/tailwind-config/tailwind.config.ts
@@ -6,7 +6,6 @@ export default {
     "../../apps/**/src/**/*.{js,ts,jsx,tsx}",
     "../../packages/ui/src/**/*.{js,ts,jsx,tsx}",
     "../../packages/design-system/src/**/*.{js,ts,jsx,tsx}",
-
   ],
   theme: {
     extend: {
@@ -14,25 +13,21 @@ export default {
         base: "1rem",
       },
       colors: {
-        bee: {
-          primary: "#FFB700",
-          secondary: "#FFD25F",
-          disabled: "#714115",
+        primary: {
+          DEFAULT: "#FFB700",
+          foreground: "hsl(var(--primary-foreground))",
         },
+        secondary: {
+          DEFAULT: "#FFD25F",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        disabled: "#714115",
         // shadcn 변수들
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",
-        primary: {
-          DEFAULT: "hsl(var(--primary))",
-          foreground: "hsl(var(--primary-foreground))",
-        },
-        secondary: {
-          DEFAULT: "hsl(var(--secondary))",
-          foreground: "hsl(var(--secondary-foreground))",
-        },
         destructive: {
           DEFAULT: "hsl(var(--destructive))",
           foreground: "hsl(var(--destructive-foreground))",
@@ -55,6 +50,7 @@ export default {
         },
       },
       borderRadius: {
+        base: "20px",
         lg: "var(--radius)",
         md: "calc(var(--radius) - 2px)",
         sm: "calc(var(--radius) - 4px)",


### PR DESCRIPTION
### Summary 
- primary, secondary 등 shadcn이 등록했던 기본값 지우고 bee prefix로 사용했던 primary, secondary 색으로 대체
  - 이유
     - 일일이 bee 라는 prefix 적기에 번거로움
     - 디자인을 참고한 결과, shadcn 기본 색상은 사용하지 않을 것이라 판단
  - 사용: text-primary text-secondary, text-disabled (o)  / text-bee-primary (x)
- border radius 
  - 디자인에서 border 20px이 자주 사용되어 20px은 base로 둠
  - 사용: rounded-base
  
  
  ### Remarks
  - vercel git action이 자꾸 돌아서 삭제 후 테스트로 몇 번 다시 올렸습니다. 계속 나오네요.. 다시 확인해볼게요