### PR TITLE
[draft] [api] 가게 관련 api 작성, 목 데이터 세팅

### DIFF
--- a/apps/desserbee-web/src/app/[lang]/(user)/_hooks/useKakaoMap.ts
+++ b/apps/desserbee-web/src/app/[lang]/(user)/_hooks/useKakaoMap.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import markerImage from '../_assets/svg/icon-marker.svg'; // 이미지 import
+import markerImage from '../map/_assets/svg/icon-marker.svg'; // 이미지 import
 import type { MapPosition } from '@repo/entity/src/map';
 import MapService from '@repo/usecase/src/mapService';
 import StoreService from '@repo/usecase/src/storeService';

--- a/apps/desserbee-web/src/app/[lang]/(user)/_hooks/useKakaoMap.ts
+++ b/apps/desserbee-web/src/app/[lang]/(user)/_hooks/useKakaoMap.ts
@@ -1,8 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
-import markerImage from '../map/_assets/svg/icon-marker.svg'; // 이미지 import
+import markerImage from '../_assets/svg/icon-marker.svg'; // 이미지 import
 import type { MapPosition } from '@repo/entity/src/map';
 import MapService from '@repo/usecase/src/mapService';
+import StoreService from '@repo/usecase/src/storeService';
 import KakaoMapController from '@repo/infrastructures/src/controllers/kakaoMapController';
+import StoreAPIReopository from '@repo/infrastructures/src/repositories/storeAPIRepository';
 
 const generateRandomPositions = (
   center: MapPosition,
@@ -24,16 +26,19 @@ export function useKakaoMap() {
   const mapService = new MapService({
     mapController: new KakaoMapController(),
   });
+  const storeService = new StoreService({
+    storeRepository: new StoreAPIReopository(),
+  });
 
   const [errorMessage, setErrorMessage] = useState<string>();
-
   useEffect(() => {
     window.kakao.maps.load(async () => {
       const container = mapRef.current;
       if (!container) return;
 
       try {
-        const result = await mapService.getCurrentPosition();
+        const result = await mapService.getTestPosition();
+        // const result = await mapService.getCurrentPosition();
 
         if ('errorMessage' in result) {
           setErrorMessage(result.errorMessage as string); // geoLocation error
@@ -41,7 +46,18 @@ export function useKakaoMap() {
         }
 
         await mapService.initializeMap(container, result);
-        const positions = generateRandomPositions(result, 100);
+        // const positions = generateRandomPositions(result, 100);
+
+        const stores = await storeService.getNearbyStores({
+          latitude: 37.498095,
+          longitude: 127.028979,
+          radius: 2,
+        });
+
+        const positions: MapPosition[] = stores.map((store) => ({
+          latitude: store.latitude,
+          longitude: store.longitude,
+        }));
 
         mapService.addMarkersWithClustering(positions, markerImage.src);
       } catch (error) {

--- a/apps/desserbee-web/src/app/[lang]/(user)/_hooks/useKakaoMap.ts
+++ b/apps/desserbee-web/src/app/[lang]/(user)/_hooks/useKakaoMap.ts
@@ -5,6 +5,7 @@ import MapService from '@repo/usecase/src/mapService';
 import StoreService from '@repo/usecase/src/storeService';
 import KakaoMapController from '@repo/infrastructures/src/controllers/kakaoMapController';
 import StoreAPIReopository from '@repo/infrastructures/src/repositories/storeAPIRepository';
+import AuthAPIRespository from '@repo/infrastructures/src/repositories/authAPIRespository';
 
 export function useKakaoMap() {
   const mapRef = useRef<HTMLDivElement>(null);
@@ -12,6 +13,7 @@ export function useKakaoMap() {
     mapController: new KakaoMapController(),
   });
   const storeService = new StoreService({
+    authRepository: new AuthAPIRespository(),
     storeRepository: new StoreAPIReopository(),
   });
 
@@ -32,8 +34,8 @@ export function useKakaoMap() {
         await mapService.initializeMap(container, result);
 
         const stores = await storeService.getNearbyStores({
-          latitude: 37.498095,
-          longitude: 127.028979,
+          latitude: result.latitude,
+          longitude: result.longitude,
           radius: 2,
         });
 

--- a/apps/desserbee-web/src/app/[lang]/(user)/_hooks/useKakaoMap.ts
+++ b/apps/desserbee-web/src/app/[lang]/(user)/_hooks/useKakaoMap.ts
@@ -6,21 +6,6 @@ import StoreService from '@repo/usecase/src/storeService';
 import KakaoMapController from '@repo/infrastructures/src/controllers/kakaoMapController';
 import StoreAPIReopository from '@repo/infrastructures/src/repositories/storeAPIRepository';
 
-const generateRandomPositions = (
-  center: MapPosition,
-  count: number,
-): MapPosition[] => {
-  const RADIUS = 0.01;
-  return Array.from({ length: count }, () => {
-    const randomAngle = Math.random() * 2 * Math.PI;
-    const randomRadius = Math.random() * RADIUS;
-    return {
-      latitude: center.latitude + randomRadius * Math.cos(randomAngle),
-      longitude: center.longitude + randomRadius * Math.sin(randomAngle),
-    };
-  });
-};
-
 export function useKakaoMap() {
   const mapRef = useRef<HTMLDivElement>(null);
   const mapService = new MapService({
@@ -37,8 +22,7 @@ export function useKakaoMap() {
       if (!container) return;
 
       try {
-        const result = await mapService.getTestPosition();
-        // const result = await mapService.getCurrentPosition();
+        const result = await mapService.getCurrentPosition();
 
         if ('errorMessage' in result) {
           setErrorMessage(result.errorMessage as string); // geoLocation error
@@ -46,7 +30,6 @@ export function useKakaoMap() {
         }
 
         await mapService.initializeMap(container, result);
-        // const positions = generateRandomPositions(result, 100);
 
         const stores = await storeService.getNearbyStores({
           latitude: 37.498095,

--- a/apps/desserbee-web/src/app/[lang]/(user)/_hooks/useKakaoMap.ts
+++ b/apps/desserbee-web/src/app/[lang]/(user)/_hooks/useKakaoMap.ts
@@ -5,7 +5,6 @@ import MapService from '@repo/usecase/src/mapService';
 import StoreService from '@repo/usecase/src/storeService';
 import KakaoMapController from '@repo/infrastructures/src/controllers/kakaoMapController';
 import StoreAPIReopository from '@repo/infrastructures/src/repositories/storeAPIRepository';
-import AuthAPIRespository from '@repo/infrastructures/src/repositories/authAPIRespository';
 
 export function useKakaoMap() {
   const mapRef = useRef<HTMLDivElement>(null);
@@ -13,7 +12,6 @@ export function useKakaoMap() {
     mapController: new KakaoMapController(),
   });
   const storeService = new StoreService({
-    authRepository: new AuthAPIRespository(),
     storeRepository: new StoreAPIReopository(),
   });
 

--- a/apps/desserbee-web/src/app/[lang]/(user)/map/_components/KakaoMap.tsx
+++ b/apps/desserbee-web/src/app/[lang]/(user)/map/_components/KakaoMap.tsx
@@ -1,27 +1,81 @@
 'use client';
 
-import { useKakaoMap } from '@/app/[lang]/(user)/_hooks/useKakaoMap';
-import type { ReactNode } from 'react';
+import { useRef, useState, type ReactNode } from 'react';
+import Script from 'next/script';
+import type { MapPosition } from '@repo/entity/src/map';
+
+import markerImage from '../_assets/svg/icon-marker.svg'; // 이미지 import
+
+import MapService from '@repo/usecase/src/mapService';
+import StoreService from '@repo/usecase/src/storeService';
+
+import KakaoMapController from '@repo/infrastructures/src/controllers/kakaoMapController';
+import StoreAPIReopository from '@repo/infrastructures/src/repositories/storeAPIRepository';
 
 interface KakoMapProps {
   children: ReactNode;
 }
 export function KakaoMap({ children }: KakoMapProps) {
-  const { mapRef, errorMessage } = useKakaoMap();
+  const mapRef = useRef<HTMLDivElement>(null);
+  const mapService = new MapService({
+    mapController: new KakaoMapController(),
+  });
+  const storeService = new StoreService({
+    storeRepository: new StoreAPIReopository(),
+  });
 
-  if (errorMessage) {
-    return (
-      <div className="relative flex justify-center items-center my-[26px] rounded-base w-full h-100vh min-h-[574px]">
-        {errorMessage}
-      </div>
-    );
-  }
+  const [errorMessage, setErrorMessage] = useState<string>();
+
+  const KAKAO_MAP_API_URL = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_API_KEY}&libraries=services,clusterer&autoload=false`;
+
   return (
-    <div
-      ref={mapRef}
-      className="relative bg-gray-400 my-[26px] rounded-base w-full h-100vh min-h-[574px] overflow-x-hidden"
-    >
-      {children}
+    <div>
+      <Script
+        type="text/javascript"
+        async
+        src={KAKAO_MAP_API_URL}
+        onLoad={() => {
+          window.kakao.maps.load(async () => {
+            const container = mapRef.current;
+            if (!container) return;
+
+            try {
+              const result = await mapService.getCurrentPosition();
+
+              if ('errorMessage' in result) {
+                setErrorMessage(result.errorMessage as string); // geoLocation error
+                return;
+              }
+
+              await mapService.initializeMap(container, result);
+
+              const stores = await storeService.getNearbyStores({
+                latitude: result.latitude,
+                longitude: result.longitude,
+                radius: 2,
+              });
+
+              const positions: MapPosition[] = stores.map((store) => ({
+                latitude: store.latitude,
+                longitude: store.longitude,
+              }));
+
+              mapService.addMarkersWithClustering(positions, markerImage.src);
+            } catch (error) {
+              if (error instanceof Error) {
+                setErrorMessage(error.message);
+              }
+            }
+          });
+        }}
+      />
+
+      <div
+        ref={mapRef}
+        className="relative bg-gray-100 my-[26px] rounded-base w-full h-100vh min-h-[574px] overflow-x-hidden"
+      >
+        {errorMessage ? errorMessage : children}
+      </div>
     </div>
   );
 }

--- a/apps/desserbee-web/src/app/[lang]/(user)/map/page.tsx
+++ b/apps/desserbee-web/src/app/[lang]/(user)/map/page.tsx
@@ -3,14 +3,17 @@ import { KakaoMap } from './_components/KakaoMap';
 import { PreferenceTags } from './_components/PreferenceTags';
 
 import { CATEGORIES } from './_consts/tag';
+
 export default function MapPage() {
   return (
-    <div className="flex flex-col">
-      <div className="px-base">
-        <KakaoMap>
-          <PreferenceTags categories={CATEGORIES} />
-        </KakaoMap>
-        <BannerCarousel />
+    <div>
+      <div className="flex flex-col">
+        <div className="px-base">
+          <KakaoMap>
+            <PreferenceTags categories={CATEGORIES} />
+          </KakaoMap>
+          <BannerCarousel />
+        </div>
       </div>
     </div>
   );

--- a/apps/desserbee-web/src/app/[lang]/layout.tsx
+++ b/apps/desserbee-web/src/app/[lang]/layout.tsx
@@ -5,7 +5,8 @@ import type { WithParams } from '@/app';
 import type { WithChildren } from '@repo/ui';
 import { SupportISO639Language } from '@repo/entity/src/i18n';
 import I18nService from '@repo/usecase/src/i18nService';
-import { initMSW } from '@/mocks';
+import { initServerMSW } from '@/mocks';
+import { MockProvider } from '@/mocks/MockProvider';
 import MetadataService from '@/usecases/metadataService';
 import Script from 'next/script';
 
@@ -20,7 +21,7 @@ export const metadata: Metadata = {
 };
 
 if (process.env.NEXT_PUBLIC_USE_API_MOCKING === 'true') {
-  initMSW();
+  initServerMSW();
 }
 
 export async function generateStaticParams() {
@@ -41,6 +42,12 @@ export default async function RootLayout({
   const i18nService = new I18nService({ store: await params });
   const lang = i18nService.getLang();
 
+  let content = children;
+
+  if (process.env.NEXT_PUBLIC_USE_API_MOCKING === 'true') {
+    content = <MockProvider>{children}</MockProvider>;
+  }
+
   return (
     <html lang={lang}>
       <body>
@@ -50,8 +57,7 @@ export default async function RootLayout({
           src={KAKAO_MAP_API_URL}
           async={false}
         />
-
-        {children}
+        {content}
       </body>
     </html>
   );

--- a/apps/desserbee-web/src/app/[lang]/layout.tsx
+++ b/apps/desserbee-web/src/app/[lang]/layout.tsx
@@ -8,7 +8,6 @@ import I18nService from '@repo/usecase/src/i18nService';
 import { initServerMSW } from '@/mocks';
 import { MockProvider } from '@/mocks/MockProvider';
 import MetadataService from '@/usecases/metadataService';
-import Script from 'next/script';
 import { Fragment } from 'react';
 
 const metadataService = new MetadataService();
@@ -34,8 +33,6 @@ export async function generateStaticParams() {
 
 interface Props extends WithChildren, WithParams {}
 
-const KAKAO_MAP_API_URL = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_API_KEY}&libraries=services,clusterer&autoload=false`;
-
 export default async function RootLayout({
   children,
   params,
@@ -50,12 +47,6 @@ export default async function RootLayout({
   return (
     <html lang={lang}>
       <body>
-        <Script
-          type="text/javascript"
-          strategy="beforeInteractive"
-          src={KAKAO_MAP_API_URL}
-          async={false}
-        />
         <Wrapper>{children}</Wrapper>
       </body>
     </html>

--- a/apps/desserbee-web/src/app/[lang]/layout.tsx
+++ b/apps/desserbee-web/src/app/[lang]/layout.tsx
@@ -50,6 +50,7 @@ export default async function RootLayout({
           src={KAKAO_MAP_API_URL}
           async={false}
         />
+
         {children}
       </body>
     </html>

--- a/apps/desserbee-web/src/app/[lang]/layout.tsx
+++ b/apps/desserbee-web/src/app/[lang]/layout.tsx
@@ -9,6 +9,7 @@ import { initServerMSW } from '@/mocks';
 import { MockProvider } from '@/mocks/MockProvider';
 import MetadataService from '@/usecases/metadataService';
 import Script from 'next/script';
+import { Fragment } from 'react';
 
 const metadataService = new MetadataService();
 
@@ -42,11 +43,9 @@ export default async function RootLayout({
   const i18nService = new I18nService({ store: await params });
   const lang = i18nService.getLang();
 
-  let content = children;
+  const isMocking = process.env.NEXT_PUBLIC_USE_API_MOCKING === 'true';
 
-  if (process.env.NEXT_PUBLIC_USE_API_MOCKING === 'true') {
-    content = <MockProvider>{children}</MockProvider>;
-  }
+  const Wrapper = isMocking ? MockProvider : Fragment;
 
   return (
     <html lang={lang}>
@@ -57,7 +56,7 @@ export default async function RootLayout({
           src={KAKAO_MAP_API_URL}
           async={false}
         />
-        {content}
+        <Wrapper>{children}</Wrapper>
       </body>
     </html>
   );

--- a/apps/desserbee-web/src/middleware.ts
+++ b/apps/desserbee-web/src/middleware.ts
@@ -35,7 +35,7 @@ export async function middleware(request: NextRequest) {
   // }
 
   const pathnameHasLocale = Object.values(SupportISO639Language).some(
-    (locale) => pathname.startsWith(`/${locale}/`) || pathname === `/${locale}`
+    (locale) => pathname.startsWith(`/${locale}/`) || pathname === `/${locale}`,
   );
 
   if (!pathnameHasLocale) {
@@ -70,7 +70,7 @@ export const config = {
      * - favicon.ico (favicon file)
      * - robots.txt (control crawler traffic)
      */
-    '/((?!api|_next/static|_next/image|favicon.ico|robots.txt).*)',
+    '/((?!api|_next/static|_next/image|favicon.ico|robots.txt|mockServiceWorker.js).*)',
   ],
 };
 
@@ -95,9 +95,7 @@ function getLocale(request: NextRequest): SupportISO639Language {
  * @param request 요청 객체
  * @returns 토큰
  */
-async function getToken(
-  request: NextRequest
-): Promise<string | void> {
+async function getToken(request: NextRequest): Promise<string | void> {
   const { cookies } = request;
 
   // FIXME: cookie key값 미확정
@@ -137,7 +135,7 @@ async function getToken(
   }
 
   const response = await authService.getAuthorization(
-    newAccessToken ?? accessToken
+    newAccessToken ?? accessToken,
   );
 
   if (!response) {

--- a/apps/desserbee-web/src/mocks/MockProvider.tsx
+++ b/apps/desserbee-web/src/mocks/MockProvider.tsx
@@ -1,0 +1,34 @@
+'use client';
+import { useEffect, useRef, useState } from 'react';
+
+export function MockProvider({ children }: { children: React.ReactNode }) {
+  const [isMocking, setIsMocking] = useState(false);
+  const isWorkerStarted = useRef(false);
+
+  useEffect(() => {
+    async function enableApiMocking() {
+      if (typeof window !== 'undefined' && !isWorkerStarted.current) {
+        try {
+          isWorkerStarted.current = true;
+          const { worker } = await import('../mocks/browser');
+
+          await worker.start({
+            onUnhandledRequest: 'bypass', // 모든 미처리 요청 무시
+          });
+          console.log('☄️ Browser mock initialized');
+          setIsMocking(true);
+        } catch (error) {
+          console.error('❌ MSW Worker failed to start:', error);
+        }
+      }
+    }
+
+    enableApiMocking();
+  }, []);
+
+  if (!isMocking) {
+    return null; // Worker 활성화 전에는 컴포넌트를 렌더링하지 않음
+  }
+
+  return <>{children}</>; // Worker 활성화 후 컴포넌트 렌더링
+}

--- a/apps/desserbee-web/src/mocks/handlers/index.ts
+++ b/apps/desserbee-web/src/mocks/handlers/index.ts
@@ -1,4 +1,5 @@
-import { HttpHandler } from "msw";
-import { userHandlers } from "./user-handlers";
+import { HttpHandler } from 'msw';
+import { userHandlers } from './user-handlers';
+import { storeHandlers } from './store-handlers';
 
-export const handlers: HttpHandler[] = [...userHandlers];
+export const handlers: HttpHandler[] = [...userHandlers, ...storeHandlers];

--- a/apps/desserbee-web/src/mocks/handlers/store-handlers.ts
+++ b/apps/desserbee-web/src/mocks/handlers/store-handlers.ts
@@ -7,60 +7,70 @@ import type {
 } from '@repo/entity/src/store';
 
 export const storeHandlers = [
-  http.get(
-    `${process.env.NEXT_PUBLIC_APP_HOST}/api/stores?latitude=37.498095&longitude=127.02761&radius=2`,
-    () => {
-      // StoreMapData[]
-      const storeMapDataList: StoreMapData[] = [
-        {
-          id: 1,
-          name: '디저트39 강남점',
-          address: '서울 강남구 강남대로 396',
-          latitude: 37.497175,
-          longitude: 127.027926,
-        },
-        {
-          id: 2,
-          name: '아티제 강남역점',
-          address: '서울 강남구 테헤란로 151',
-          latitude: 37.499462,
-          longitude: 127.028274,
-        },
-        {
-          id: 3,
-          name: '투썸플레이스 강남파이낸스센터점',
-          address: '서울 강남구 테헤란로 152',
-          latitude: 37.500175,
-          longitude: 127.029046,
-        },
-        {
-          id: 4,
-          name: '설빙 강남역점',
-          address: '서울 강남구 강남대로 358',
-          latitude: 37.496533,
-          longitude: 127.0268,
-        },
-        {
-          id: 5,
-          name: '폴바셋 강남역사거리점',
-          address: '서울 강남구 테헤란로 129',
-          latitude: 37.498325,
-          longitude: 127.027892,
-        },
-        {
-          id: 6,
-          name: '배스킨라빈스 강남우성점',
-          address: '서울 강남구 테헤란로 156',
-          latitude: 37.500929,
-          longitude: 127.028979,
-        },
-      ];
+  http.get('http://localhost:3000/api/stores', ({ request }) => {
+    const url = new URL(request.url);
+    const latitude = url.searchParams.get('latitude');
+    const longitude = url.searchParams.get('longitude');
+    const radius = url.searchParams.get('radius');
 
+    // StoreMapData[]
+    const storeMapDataList: StoreMapData[] = [
+      {
+        id: 1,
+        name: '디저트39 강남점',
+        address: '서울 강남구 강남대로 396',
+        latitude: 37.497175,
+        longitude: 127.027926,
+      },
+      {
+        id: 2,
+        name: '아티제 강남역점',
+        address: '서울 강남구 테헤란로 151',
+        latitude: 37.499462,
+        longitude: 127.028274,
+      },
+      {
+        id: 3,
+        name: '투썸플레이스 강남파이낸스센터점',
+        address: '서울 강남구 테헤란로 152',
+        latitude: 37.500175,
+        longitude: 127.029046,
+      },
+      {
+        id: 4,
+        name: '설빙 강남역점',
+        address: '서울 강남구 강남대로 358',
+        latitude: 37.496533,
+        longitude: 127.0268,
+      },
+      {
+        id: 5,
+        name: '폴바셋 강남역사거리점',
+        address: '서울 강남구 테헤란로 129',
+        latitude: 37.498325,
+        longitude: 127.027892,
+      },
+      {
+        id: 6,
+        name: '배스킨라빈스 강남우성점',
+        address: '서울 강남구 테헤란로 156',
+        latitude: 37.500929,
+        longitude: 127.028979,
+      },
+    ];
+
+    if (
+      latitude === '37.498095' &&
+      longitude === '127.02761' &&
+      radius === '2'
+    ) {
       return HttpResponse.json(storeMapDataList);
-    },
-  ),
+    }
 
-  http.get(`${process.env.NEXT_PUBLIC_APP_HOST}/api/stores/1/details`, () => {
+    return HttpResponse.json([]);
+  }),
+
+  http.get(`http://localhost:3000/api/stores/1/details`, () => {
     // StoreDetailData
     const storeDetailData: StoreDetailData = {
       id: 1,
@@ -120,7 +130,7 @@ export const storeHandlers = [
     return HttpResponse.json(storeDetailData);
   }),
 
-  http.get(`${process.env.NEXT_PUBLIC_APP_HOST}/api/store/1/summary`, () => {
+  http.get(`http://localhost:3000/api/store/1/summary`, () => {
     const storeSummaryData: StoreSummaryData = {
       id: 1,
       name: '스타벅스 강남점',
@@ -143,57 +153,54 @@ export const storeHandlers = [
     return HttpResponse.json(storeSummaryData);
   }),
 
-  http.get(
-    `${process.env.NEXT_PUBLIC_APP_HOST}/api/users/1/saved-stores`,
-    () => {
-      // StoreDetailData
-      const storeSavedByUserDataList: StoreSavedByUserData[] = [
-        {
-          id: 1,
-          storeId: 1,
-          storeName: '스타벅스 강남점',
-          address: '서울 강남구 테헤란로 101',
-          storeLink: 'https://instagram.com/store1',
-          savedAt: '2024-02-07T09:00:00Z',
-        },
-        {
-          id: 2,
-          storeId: 2,
-          storeName: '투썸플레이스 역삼점',
-          address: '서울 강남구 역삼로 110',
-          storeLink: 'https://instagram.com/store2',
-          savedAt: '2024-02-06T15:30:00Z',
-        },
-        {
-          id: 3,
-          storeId: 3,
-          storeName: '폴바셋 선릉점',
-          address: '서울 강남구 선릉로 123',
-          storeLink: 'https://instagram.com/store3',
-          savedAt: '2024-02-05T11:20:00Z',
-        },
-        {
-          id: 4,
-          storeId: 4,
-          storeName: '커피빈 삼성점',
-          address: '서울 강남구 삼성로 145',
-          storeLink: 'https://instagram.com/store4',
-          savedAt: '2024-02-04T16:45:00Z',
-        },
-        {
-          id: 5,
-          storeId: 5,
-          storeName: '블루보틀 압구정점',
-          address: '서울 강남구 압구정로 156',
-          storeLink: 'https://instagram.com/store5',
-          savedAt: '2024-02-03T13:15:00Z',
-        },
-      ];
-      return HttpResponse.json(storeSavedByUserDataList);
-    },
-  ),
+  http.get(`http://localhost:3000/api/users/1/saved-stores`, () => {
+    // StoreDetailData
+    const storeSavedByUserDataList: StoreSavedByUserData[] = [
+      {
+        id: 1,
+        storeId: 1,
+        storeName: '스타벅스 강남점',
+        address: '서울 강남구 테헤란로 101',
+        storeLink: 'https://instagram.com/store1',
+        savedAt: '2024-02-07T09:00:00Z',
+      },
+      {
+        id: 2,
+        storeId: 2,
+        storeName: '투썸플레이스 역삼점',
+        address: '서울 강남구 역삼로 110',
+        storeLink: 'https://instagram.com/store2',
+        savedAt: '2024-02-06T15:30:00Z',
+      },
+      {
+        id: 3,
+        storeId: 3,
+        storeName: '폴바셋 선릉점',
+        address: '서울 강남구 선릉로 123',
+        storeLink: 'https://instagram.com/store3',
+        savedAt: '2024-02-05T11:20:00Z',
+      },
+      {
+        id: 4,
+        storeId: 4,
+        storeName: '커피빈 삼성점',
+        address: '서울 강남구 삼성로 145',
+        storeLink: 'https://instagram.com/store4',
+        savedAt: '2024-02-04T16:45:00Z',
+      },
+      {
+        id: 5,
+        storeId: 5,
+        storeName: '블루보틀 압구정점',
+        address: '서울 강남구 압구정로 156',
+        storeLink: 'https://instagram.com/store5',
+        savedAt: '2024-02-03T13:15:00Z',
+      },
+    ];
+    return HttpResponse.json(storeSavedByUserDataList);
+  }),
 
-  http.get(`${process.env.NEXT_PUBLIC_APP_HOST}/api/store`, () => {
+  http.get(`http://localhost:3000/api/store`, () => {
     return HttpResponse.json({});
   }),
 ];

--- a/apps/desserbee-web/src/mocks/handlers/store-handlers.ts
+++ b/apps/desserbee-web/src/mocks/handlers/store-handlers.ts
@@ -1,0 +1,199 @@
+import { http, HttpResponse } from 'msw';
+import type {
+  StoreDetailData,
+  StoreMapData,
+  StoreSavedByUserData,
+  StoreSummaryData,
+} from '@repo/entity/src/store';
+
+export const storeHandlers = [
+  http.get(
+    `${process.env.NEXT_PUBLIC_APP_HOST}/api/stores?latitude=37.498095&longitude=127.02761&radius=2`,
+    () => {
+      // StoreMapData[]
+      const storeMapDataList: StoreMapData[] = [
+        {
+          id: 1,
+          name: '디저트39 강남점',
+          address: '서울 강남구 강남대로 396',
+          latitude: 37.497175,
+          longitude: 127.027926,
+        },
+        {
+          id: 2,
+          name: '아티제 강남역점',
+          address: '서울 강남구 테헤란로 151',
+          latitude: 37.499462,
+          longitude: 127.028274,
+        },
+        {
+          id: 3,
+          name: '투썸플레이스 강남파이낸스센터점',
+          address: '서울 강남구 테헤란로 152',
+          latitude: 37.500175,
+          longitude: 127.029046,
+        },
+        {
+          id: 4,
+          name: '설빙 강남역점',
+          address: '서울 강남구 강남대로 358',
+          latitude: 37.496533,
+          longitude: 127.0268,
+        },
+        {
+          id: 5,
+          name: '폴바셋 강남역사거리점',
+          address: '서울 강남구 테헤란로 129',
+          latitude: 37.498325,
+          longitude: 127.027892,
+        },
+        {
+          id: 6,
+          name: '배스킨라빈스 강남우성점',
+          address: '서울 강남구 테헤란로 156',
+          latitude: 37.500929,
+          longitude: 127.028979,
+        },
+      ];
+
+      return HttpResponse.json(storeMapDataList);
+    },
+  ),
+
+  http.get(`${process.env.NEXT_PUBLIC_APP_HOST}/api/stores/1/details`, () => {
+    // StoreDetailData
+    const storeDetailData: StoreDetailData = {
+      id: 1,
+      name: '스타벅스 강남점',
+      address: '서울 강남구 테헤란로 101',
+      operatingHours: '09:00-22:00',
+      closingDays: '연중무휴',
+      phone: '02-555-1234',
+      storeLink: 'https://instagram.com/store1',
+      animalYn: true,
+      tumblerYn: true,
+      parkingYn: false,
+      averageRating: 4.5,
+      events: [
+        {
+          id: 1,
+          title: '여름 시즌 프로모션',
+          description: '아이스 음료 20% 할인',
+          startDate: new Date('2024-07-01'),
+          endDate: new Date('2024-08-31'),
+          images: ['https://picsum.photos/id/44/800/600'],
+        },
+      ],
+      menus: [
+        {
+          id: 1,
+          name: '아메리카노',
+          price: 4500,
+          isPopular: true,
+          description: '깊고 진한 에스프레소의 맛',
+          images: ['https://picsum.photos/id/45/800/600'],
+        },
+      ],
+      coupons: [
+        {
+          title: '신규 가입 쿠폰',
+          description: '첫 주문 시 3,000원 할인',
+          expiryDate: '2024-12-31',
+        },
+      ],
+      storeImages: [
+        'https://picsum.photos/id/46/800/600',
+        'https://picsum.photos/id/47/800/600',
+      ],
+      storeReviews: [
+        {
+          id: 1,
+          storeId: 1,
+          content: '분위기가 너무 좋아요!',
+          rating: 5,
+          createdAt: '2024-02-07T09:00:00Z',
+          images: ['https://picsum.photos/id/48/800/600'],
+        },
+      ],
+      tags: ['베이커리', '루프탑 있음', '애완동물 동반 가능'],
+    };
+    return HttpResponse.json(storeDetailData);
+  }),
+
+  http.get(`${process.env.NEXT_PUBLIC_APP_HOST}/api/store/1/summary`, () => {
+    const storeSummaryData: StoreSummaryData = {
+      id: 1,
+      name: '스타벅스 강남점',
+      phone: '02-555-1234',
+      address: '서울 강남구 테헤란로 101',
+      storeLink: 'https://instagram.com/store1',
+      averageRating: 4.5,
+      operatingHours: '09:00-22:00',
+      closingDays: '연중무휴',
+      animalYn: true,
+      tumblerYn: true,
+      parkingYn: false,
+      tags: ['베이커리', '루프탑 있음', '애완동물 동반 가능'],
+      storeImages: [
+        'https://picsum.photos/id/42/800/600',
+        'https://picsum.photos/id/43/800/600',
+      ],
+    };
+
+    return HttpResponse.json(storeSummaryData);
+  }),
+
+  http.get(
+    `${process.env.NEXT_PUBLIC_APP_HOST}/api/users/1/saved-stores`,
+    () => {
+      // StoreDetailData
+      const storeSavedByUserDataList: StoreSavedByUserData[] = [
+        {
+          id: 1,
+          storeId: 1,
+          storeName: '스타벅스 강남점',
+          address: '서울 강남구 테헤란로 101',
+          storeLink: 'https://instagram.com/store1',
+          savedAt: '2024-02-07T09:00:00Z',
+        },
+        {
+          id: 2,
+          storeId: 2,
+          storeName: '투썸플레이스 역삼점',
+          address: '서울 강남구 역삼로 110',
+          storeLink: 'https://instagram.com/store2',
+          savedAt: '2024-02-06T15:30:00Z',
+        },
+        {
+          id: 3,
+          storeId: 3,
+          storeName: '폴바셋 선릉점',
+          address: '서울 강남구 선릉로 123',
+          storeLink: 'https://instagram.com/store3',
+          savedAt: '2024-02-05T11:20:00Z',
+        },
+        {
+          id: 4,
+          storeId: 4,
+          storeName: '커피빈 삼성점',
+          address: '서울 강남구 삼성로 145',
+          storeLink: 'https://instagram.com/store4',
+          savedAt: '2024-02-04T16:45:00Z',
+        },
+        {
+          id: 5,
+          storeId: 5,
+          storeName: '블루보틀 압구정점',
+          address: '서울 강남구 압구정로 156',
+          storeLink: 'https://instagram.com/store5',
+          savedAt: '2024-02-03T13:15:00Z',
+        },
+      ];
+      return HttpResponse.json(storeSavedByUserDataList);
+    },
+  ),
+
+  http.get(`${process.env.NEXT_PUBLIC_APP_HOST}/api/store`, () => {
+    return HttpResponse.json({});
+  }),
+];

--- a/apps/desserbee-web/src/mocks/handlers/store-handlers.ts
+++ b/apps/desserbee-web/src/mocks/handlers/store-handlers.ts
@@ -7,7 +7,7 @@ import type {
 } from '@repo/entity/src/store';
 
 export const storeHandlers = [
-  http.get('http://localhost:3000/api/stores', ({ request }) => {
+  http.get('http://localhost:3000/api/stores', async ({ request }) => {
     const url = new URL(request.url);
     const latitude = url.searchParams.get('latitude');
     const longitude = url.searchParams.get('longitude');
@@ -60,17 +60,27 @@ export const storeHandlers = [
     ];
 
     if (
-      latitude === '37.498095' &&
-      longitude === '127.02761' &&
-      radius === '2'
+      Number(latitude) === 37.498095 &&
+      Number(longitude) === 127.028979 &&
+      Number(radius) === 2
     ) {
-      return HttpResponse.json(storeMapDataList);
+      return new HttpResponse(JSON.stringify(storeMapDataList), {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
     }
 
-    return HttpResponse.json([]);
+    return new HttpResponse(JSON.stringify([]), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
   }),
 
-  http.get(`http://localhost:3000/api/stores/1/details`, () => {
+  http.get(`http://localhost:3000/api/stores/1/details`, async () => {
     // StoreDetailData
     const storeDetailData: StoreDetailData = {
       id: 1,
@@ -130,7 +140,7 @@ export const storeHandlers = [
     return HttpResponse.json(storeDetailData);
   }),
 
-  http.get(`http://localhost:3000/api/store/1/summary`, () => {
+  http.get(`http://localhost:3000/api/store/1/summary`, async () => {
     const storeSummaryData: StoreSummaryData = {
       id: 1,
       name: '스타벅스 강남점',
@@ -153,7 +163,7 @@ export const storeHandlers = [
     return HttpResponse.json(storeSummaryData);
   }),
 
-  http.get(`http://localhost:3000/api/users/1/saved-stores`, () => {
+  http.get(`/api/users/1/saved-stores`, () => {
     // StoreDetailData
     const storeSavedByUserDataList: StoreSavedByUserData[] = [
       {
@@ -197,10 +207,15 @@ export const storeHandlers = [
         savedAt: '2024-02-03T13:15:00Z',
       },
     ];
-    return HttpResponse.json(storeSavedByUserDataList);
+    return new HttpResponse(JSON.stringify(storeSavedByUserDataList), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
   }),
 
-  http.get(`http://localhost:3000/api/store`, () => {
+  http.get(`/api/store`, async () => {
     return HttpResponse.json({});
   }),
 ];

--- a/apps/desserbee-web/src/mocks/handlers/user-handlers.ts
+++ b/apps/desserbee-web/src/mocks/handlers/user-handlers.ts
@@ -1,19 +1,19 @@
-import { http, HttpResponse } from "msw";
+import { http, HttpResponse } from 'msw';
 
 export const userHandlers = [
-  http.get("https://example.com/user", () => {
+  http.get('https://example.com/user', () => {
     return HttpResponse.json({
-      id: "c7b3d8e0-5e0b-4b0f-8b3a-3b9f4b3d3b3d",
-      firstName: "John",
-      lastName: "Maverick",
+      id: 'c7b3d8e0-5e0b-4b0f-8b3a-3b9f4b3d3b3d',
+      firstName: 'John',
+      lastName: 'Maverick',
     });
   }),
 
-  http.get("http://localhost:3000/user", () => {
+  http.get(`${process.env.NEXT_PUBLIC_APP_HOST}/api/user`, () => {
     return HttpResponse.json({
-      id: "c7b3d8e0-5e0b-4b0f-8b3a-3b9f4b3d3b3d",
-      firstName: "John",
-      lastName: "Maverick",
+      id: 'c7b3d8e0-5e0b-4b0f-8b3a-3b9f4b3d3b3d',
+      firstName: 'John',
+      lastName: 'Maverick',
     });
   }),
 ];

--- a/apps/desserbee-web/src/mocks/index.ts
+++ b/apps/desserbee-web/src/mocks/index.ts
@@ -1,14 +1,16 @@
 async function initMSW() {
-  if (typeof window === "undefined") {
-    const { server } = await import("./server");
+  if (typeof window === 'undefined') {
+    const { server } = await import('./server');
 
-    console.log("server mock");
+    console.log('server mock');
     server.listen();
   } else {
-    const { worker } = await import("./browser");
+    const { worker } = await import('./browser');
 
-    console.log("broswer mock");
-    await worker.start();
+    console.log('broswer mock');
+    await worker.start({
+      onUnhandledRequest: 'bypass', // 모든 미처리 요청 무시
+    });
   }
 }
 

--- a/apps/desserbee-web/src/mocks/index.ts
+++ b/apps/desserbee-web/src/mocks/index.ts
@@ -1,17 +1,9 @@
-async function initMSW() {
+async function initServerMSW() {
   if (typeof window === 'undefined') {
     const { server } = await import('./server');
-
-    console.log('server mock');
+    console.log('🌌 Server mock initialized');
     server.listen();
-  } else {
-    const { worker } = await import('./browser');
-
-    console.log('broswer mock');
-    await worker.start({
-      onUnhandledRequest: 'bypass', // 모든 미처리 요청 무시
-    });
   }
 }
 
-export { initMSW };
+export { initServerMSW };

--- a/packages/entity/src/review.ts
+++ b/packages/entity/src/review.ts
@@ -1,0 +1,24 @@
+export interface Review {
+  id: number;
+  userId: number;
+  storeId: number;
+  title: string;
+  content: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface ReviewTag {
+  id: number;
+  name: string;
+}
+
+export interface StoreReview {
+  id: number;
+  storeId: number;
+  userId: number;
+  content: string;
+  rating: number;
+  images: string[];
+  createdAt?: string;
+}

--- a/packages/entity/src/store.ts
+++ b/packages/entity/src/store.ts
@@ -1,69 +1,187 @@
-export interface StoreMapData {
+import type { BaseRequestData } from './appMetadata';
+import type { StoreReview } from './review';
+
+export interface Store {
   id: number;
   name: string;
+  phone: string;
   address: string;
+  storeLink: string;
   latitude: number;
   longitude: number;
-}
-
-export interface StoreSummaryData {
-  id: number;
-  name: string;
-  averageRating: number;
-  tags: string[];
-  storeImages: string[];
-  address: string;
+  description: string;
+  animalYn: boolean;
+  parkingYn: boolean;
+  tumblerYn: boolean;
   operatingHours: string;
   closingDays: string;
-  phone: string;
-  storeLink: string;
-  animalYn: boolean;
-  tumblerYn: boolean;
-  parkingYn: boolean;
+  averageRating: number;
+  status: boolean;
+  createdAt?: string;
+  updatedAt?: string;
 }
 
-export interface StoreEventData {
+export interface Menu {
   id: number;
+  storeId: number;
+  name: string;
+  isPopular: boolean; // 인기 메뉴여부
+  price: number;
+  description: string;
+  images: string[];
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface StoreEvent {
+  id: number;
+  storeId: number;
   title: string;
   description: string;
-  startDate: string;
-  endDate: string;
+  startDate: Date;
+  endDate: Date;
+  images: string[];
+  createdAt?: string;
+  updatedAt?: string;
 }
 
-export interface StoreCouponData {
+// 유저가 저장한 가게들
+export interface UserSavedStore {
+  id: number;
+  userId: number;
+  storeId: number;
+  createdAt?: string;
+}
+
+export interface StoreDetail {
+  id: number;
+  storeId: number;
+  views: number;
+  saved: number;
+  reviews: number;
+  createDate: Date;
+  createdAt?: string;
+}
+
+export interface StoreCoupon {
   title: string;
   description: string;
   expiryDate: string;
 }
 
-export type StoreTag = "베이커리" | "루프탑 있음" | "애완동물 동반 가능"; // TODO: 전체 카테고리 정리하기
+// export type StoreTag = '베이커리' | '루프탑 있음' | '애완동물 동반 가능'; // TODO: 전체 카테고리 정리하기
 
-export interface StoreDetailData {
-  id: number;
-  name: string;
-  address: string;
-  operatingHours: string;
-  closingDays: string;
-  phone: string;
-  storeLink: string;
-  animalYn: boolean;
-  tumblerYn: boolean;
-  parkingYn: boolean;
-  averageRating: number;
-  events: StoreEventData[];
-  menus: null; // TODO: 아직 api 명세서에 없음
-  coupons: StoreCouponData[];
+export type StoreMapData = Pick<
+  Store,
+  'id' | 'name' | 'address' | 'latitude' | 'longitude'
+>;
+
+export interface StoreSummaryData
+  extends Pick<
+    Store,
+    | 'id'
+    | 'name'
+    | 'phone'
+    | 'address'
+    | 'storeLink'
+    | 'averageRating'
+    | 'operatingHours'
+    | 'closingDays'
+    | 'animalYn'
+    | 'tumblerYn'
+    | 'parkingYn'
+  > {
+  tags: string[];
   storeImages: string[];
-  eventImages: string[];
-  menuImages: string[];
-  storeReviews: string[]; // TODO: 아직 api 명세서에 없음
-  tags: StoreTag[];
 }
 
-export interface StoreSavedByUserData {
+export interface StoreDetailData
+  extends Pick<
+    Store,
+    | 'id'
+    | 'name'
+    | 'address'
+    | 'operatingHours'
+    | 'closingDays'
+    | 'phone'
+    | 'storeLink'
+    | 'animalYn'
+    | 'tumblerYn'
+    | 'parkingYn'
+    | 'averageRating'
+  > {
+  events: Pick<
+    StoreEvent,
+    'id' | 'title' | 'description' | 'startDate' | 'endDate' | 'images'
+  >[];
+  menus: Pick<
+    Menu,
+    'id' | 'name' | 'price' | 'isPopular' | 'description' | 'images'
+  >[];
+  coupons: StoreCoupon[];
+  storeImages: string[];
+  storeReviews: Pick<
+    StoreReview,
+    'id' | 'storeId' | 'content' | 'rating' | 'createdAt' | 'images'
+  >[];
+  tags: string[];
+}
+
+export interface StoreSavedByUserData
+  extends Pick<Store, 'address' | 'storeLink'> {
   id: number;
-  name: string;
-  address: string;
-  thumbnail: string;
-  savedAt: string;
+  storeId: Store['id'];
+  storeName: Store['name'];
+  savedAt: string; // 유저 저장 일시
+}
+
+// TODO: api 명세서에 아직 덜 나옴
+export interface StoreRegisterData
+  extends Pick<
+    Store,
+    | 'id'
+    | 'name'
+    | 'phone'
+    | 'address'
+    | 'storeLink'
+    | 'latitude'
+    | 'longitude'
+    | 'description'
+    | 'animalYn'
+    | 'tumblerYn'
+    | 'parkingYn'
+    | 'operatingHours'
+    | 'closingDays'
+  > {
+  ownerId: number;
+  tagIds: number[];
+}
+
+export interface StoreRepository {
+  getNearbyStores(
+    data: BaseRequestData<{
+      latitude: number;
+      longitude: number;
+      radius: number;
+    }>,
+  ): Promise<StoreMapData>;
+
+  getStoreSummary(
+    data: BaseRequestData<{
+      storeId: number;
+    }>,
+  ): Promise<StoreSummaryData>;
+
+  getStoreDetail(
+    data: BaseRequestData<{
+      storeId: number;
+    }>,
+  ): Promise<StoreDetailData>;
+
+  getUserSavedStore({
+    authorization,
+    data,
+  }: BaseRequestData<{
+    userId: number;
+  }>): Promise<StoreSavedByUserData[]>;
 }

--- a/packages/entity/src/store.ts
+++ b/packages/entity/src/store.ts
@@ -1,0 +1,69 @@
+export interface StoreMapData {
+  id: number;
+  name: string;
+  address: string;
+  latitude: number;
+  longitude: number;
+}
+
+export interface StoreSummaryData {
+  id: number;
+  name: string;
+  averageRating: number;
+  tags: string[];
+  storeImages: string[];
+  address: string;
+  operatingHours: string;
+  closingDays: string;
+  phone: string;
+  storeLink: string;
+  animalYn: boolean;
+  tumblerYn: boolean;
+  parkingYn: boolean;
+}
+
+export interface StoreEventData {
+  id: number;
+  title: string;
+  description: string;
+  startDate: string;
+  endDate: string;
+}
+
+export interface StoreCouponData {
+  title: string;
+  description: string;
+  expiryDate: string;
+}
+
+export type StoreTag = "베이커리" | "루프탑 있음" | "애완동물 동반 가능"; // TODO: 전체 카테고리 정리하기
+
+export interface StoreDetailData {
+  id: number;
+  name: string;
+  address: string;
+  operatingHours: string;
+  closingDays: string;
+  phone: string;
+  storeLink: string;
+  animalYn: boolean;
+  tumblerYn: boolean;
+  parkingYn: boolean;
+  averageRating: number;
+  events: StoreEventData[];
+  menus: null; // TODO: 아직 api 명세서에 없음
+  coupons: StoreCouponData[];
+  storeImages: string[];
+  eventImages: string[];
+  menuImages: string[];
+  storeReviews: string[]; // TODO: 아직 api 명세서에 없음
+  tags: StoreTag[];
+}
+
+export interface UserSavedStoreData {
+  id: number;
+  name: string;
+  address: string;
+  thumbnail: string;
+  savedAt: string;
+}

--- a/packages/entity/src/store.ts
+++ b/packages/entity/src/store.ts
@@ -60,7 +60,7 @@ export interface StoreDetailData {
   tags: StoreTag[];
 }
 
-export interface UserSavedStoreData {
+export interface StoreSavedByUserData {
   id: number;
   name: string;
   address: string;

--- a/packages/entity/src/store.ts
+++ b/packages/entity/src/store.ts
@@ -164,7 +164,7 @@ export interface StoreRepository {
       longitude: number;
       radius: number;
     }>,
-  ): Promise<StoreMapData>;
+  ): Promise<StoreMapData[]>;
 
   getStoreSummary(
     data: BaseRequestData<{

--- a/packages/infrastructures/src/controllers/kakaoMapController.ts
+++ b/packages/infrastructures/src/controllers/kakaoMapController.ts
@@ -12,7 +12,7 @@ export default class KakaoMapController implements MapController {
           (pos) => {
             if (process.env.NEXT_PUBLIC_USE_API_MOCKING === 'true') {
               const latitude = 37.498095;
-              const longitude = 127.02761;
+              const longitude = 127.028979;
               resolve({ latitude, longitude });
             } else {
               const latitude = pos.coords.latitude;

--- a/packages/infrastructures/src/controllers/kakaoMapController.ts
+++ b/packages/infrastructures/src/controllers/kakaoMapController.ts
@@ -1,6 +1,6 @@
-import type { MapController, MapPosition } from "@repo/entity/src/map";
+import type { MapController, MapPosition } from '@repo/entity/src/map';
 
-import { KakaoMapAdapter } from "../adapters/kakaoMapAdapter";
+import { KakaoMapAdapter } from '../adapters/kakaoMapAdapter';
 
 export default class KakaoMapController implements MapController {
   private map: KakaoMapAdapter | null = null;
@@ -10,16 +10,22 @@ export default class KakaoMapController implements MapController {
       if (navigator.geolocation) {
         navigator.geolocation.getCurrentPosition(
           (pos) => {
-            const latitude = pos.coords.latitude;
-            const longitude = pos.coords.longitude;
-            resolve({ latitude, longitude });
+            if (process.env.NEXT_PUBLIC_USE_API_MOCKING === 'true') {
+              const latitude = 37.498095;
+              const longitude = 127.02761;
+              resolve({ latitude, longitude });
+            } else {
+              const latitude = pos.coords.latitude;
+              const longitude = pos.coords.longitude;
+              resolve({ latitude, longitude });
+            }
           },
           (err) => {
             if (err.code === 3) {
-              reject(new Error("delayed"));
+              reject(new Error('delayed'));
             }
             if (err.code === 1) {
-              reject(new Error("blocked"));
+              reject(new Error('blocked'));
             }
             reject(err);
           },
@@ -27,10 +33,10 @@ export default class KakaoMapController implements MapController {
             enableHighAccuracy: false,
             maximumAge: 180000,
             timeout: 7000,
-          }
+          },
         );
       } else {
-        reject(new Error("notSupport"));
+        reject(new Error('notSupport'));
       }
     });
   }
@@ -63,12 +69,12 @@ export default class KakaoMapController implements MapController {
 
     const imageSize = new kakao.maps.Size(
       markerOptions.size.width,
-      markerOptions.size.height
+      markerOptions.size.height,
     );
     const imageOffset = {
       offset: new kakao.maps.Point(
         markerOptions.offset.x,
-        markerOptions.offset.y
+        markerOptions.offset.y,
       ),
     };
 
@@ -76,7 +82,7 @@ export default class KakaoMapController implements MapController {
 
     const markerPosition = new kakao.maps.LatLng(
       position.latitude,
-      position.longitude
+      position.longitude,
     );
 
     const marker = new kakao.maps.Marker({
@@ -89,7 +95,7 @@ export default class KakaoMapController implements MapController {
 
   createMarkersWithClusterer(positions: MapPosition[], markerImageSrc: string) {
     if (!this.map) {
-      throw new Error("Map is not initialized");
+      throw new Error('Map is not initialized');
     }
     const kakaoMap = this.map.getNativeMap();
     const markers: kakao.maps.Marker[] = [];

--- a/packages/infrastructures/src/repositories/storeAPIRepository.ts
+++ b/packages/infrastructures/src/repositories/storeAPIRepository.ts
@@ -1,0 +1,89 @@
+import APIRepository from './apiRepository';
+import type {
+  StoreDetailData,
+  StoreMapData,
+  StoreRepository,
+  StoreSavedByUserData,
+  StoreSummaryData,
+} from '@repo/entity/src/store';
+import type { BaseRequestData } from '@repo/entity/src/appMetadata';
+import fetch from '@repo/api/src/fetch';
+
+export default class StoreAPIRepository
+  extends APIRepository
+  implements StoreRepository
+{
+  async getNearbyStores({
+    data,
+  }: BaseRequestData<{
+    latitude: number;
+    longitude: number;
+    radius: number;
+  }>): Promise<StoreMapData> {
+    const { latitude, longitude, radius } = data || {};
+
+    const response = await fetch<void, StoreMapData>({
+      method: 'GET',
+      url: `${this.endpoint}/stores?latitude=${latitude}&longitude=${longitude}&radius=${radius}`,
+    });
+
+    return response;
+  }
+
+  async getStoreSummary({
+    data,
+  }: BaseRequestData<{
+    storeId: number;
+  }>) {
+    const { storeId } = data || {};
+
+    const response = await fetch<void, StoreSummaryData>({
+      method: 'GET',
+      url: `${this.endpoint}/stores/${storeId}/summary`,
+    });
+
+    return response;
+  }
+
+  async getStoreDetail({
+    data,
+  }: BaseRequestData<{
+    storeId: number;
+  }>) {
+    const { storeId } = data || {};
+
+    const response = await fetch<void, StoreDetailData>({
+      method: 'GET',
+      url: `${this.endpoint}/stores/${storeId}/details`,
+    });
+
+    return response;
+  }
+
+  async getUserSavedStore({
+    authorization,
+    data,
+  }: BaseRequestData<{
+    userId: number;
+  }>) {
+    const { userId } = data || {};
+
+    const response = await fetch<void, StoreSavedByUserData[]>({
+      ...(authorization && {
+        headers: {
+          Authorization: authorization,
+        },
+      }),
+      method: 'GET',
+      url: `${this.endpoint}/users/${userId}/saved-stores`,
+    });
+
+    return response;
+  }
+
+  async registerStore() {}
+
+  async updateStore() {}
+
+  async deleteStore() {}
+}

--- a/packages/infrastructures/src/repositories/storeAPIRepository.ts
+++ b/packages/infrastructures/src/repositories/storeAPIRepository.ts
@@ -19,10 +19,10 @@ export default class StoreAPIRepository
     latitude: number;
     longitude: number;
     radius: number;
-  }>): Promise<StoreMapData> {
+  }>): Promise<StoreMapData[]> {
     const { latitude, longitude, radius } = data || {};
 
-    const response = await fetch<void, StoreMapData>({
+    const response = await fetch<void, StoreMapData[]>({
       method: 'GET',
       url: `${this.endpoint}/stores?latitude=${latitude}&longitude=${longitude}&radius=${radius}`,
     });

--- a/packages/tailwind-config/tailwind.config.ts
+++ b/packages/tailwind-config/tailwind.config.ts
@@ -3,7 +3,7 @@
 export default {
   darkMode: ['class'],
   content: [
-    '../../apps/**/src/**/*.{js,ts,jsx,tsx}',
+    '../../apps/*/src/**/*.{js,ts,jsx,tsx}',
     '../../packages/ui/src/**/*.{js,ts,jsx,tsx}',
     '../../packages/design-system/src/**/*.{js,ts,jsx,tsx}',
   ],

--- a/packages/usecase/src/mapService.ts
+++ b/packages/usecase/src/mapService.ts
@@ -10,17 +10,6 @@ export default class MapService {
   constructor({ mapController }: { mapController?: MapController }) {
     this.mapController = mapController ?? null;
   }
-  async getTestPosition(): Promise<MapPosition | MapErrorMessage> {
-    if (!this.mapController) {
-      throw new Error('mapController is not set');
-    }
-
-    return {
-      latitude: 37.498095,
-      longitude: 127.02761,
-    };
-  }
-
   async getCurrentPosition(): Promise<MapPosition | MapErrorMessage> {
     if (!this.mapController) {
       throw new Error('mapController is not set');

--- a/packages/usecase/src/mapService.ts
+++ b/packages/usecase/src/mapService.ts
@@ -1,4 +1,4 @@
-import type { MapController, MapPosition } from "@repo/entity/src/map";
+import type { MapController, MapPosition } from '@repo/entity/src/map';
 
 interface MapErrorMessage {
   errorMessage: string;
@@ -10,44 +10,54 @@ export default class MapService {
   constructor({ mapController }: { mapController?: MapController }) {
     this.mapController = mapController ?? null;
   }
+  async getTestPosition(): Promise<MapPosition | MapErrorMessage> {
+    if (!this.mapController) {
+      throw new Error('mapController is not set');
+    }
+
+    return {
+      latitude: 37.498095,
+      longitude: 127.02761,
+    };
+  }
 
   async getCurrentPosition(): Promise<MapPosition | MapErrorMessage> {
     if (!this.mapController) {
-      throw new Error("mapController is not set");
+      throw new Error('mapController is not set');
     }
 
     try {
       const permissionStatus = await navigator.permissions.query({
-        name: "geolocation",
+        name: 'geolocation',
       });
 
       let position;
       switch (permissionStatus.state) {
-        case "denied":
+        case 'denied':
           return {
-            errorMessage: "위치 권한 허용 후 서비스 이용이 가능합니다.",
+            errorMessage: '위치 권한 허용 후 서비스 이용이 가능합니다.',
           };
-        case "prompt":
+        case 'prompt':
           position = await this.mapController.getCurrentPosition();
           return position;
-        case "granted":
+        case 'granted':
           position = await this.mapController.getCurrentPosition();
           return position;
       }
     } catch (error) {
       if (error instanceof Error) {
         switch (error.message) {
-          case "delayed":
+          case 'delayed':
             return {
-              errorMessage: "위치 정보를 가져오는데 시간이 너무 오래 걸립니다.",
+              errorMessage: '위치 정보를 가져오는데 시간이 너무 오래 걸립니다.',
             };
-          case "blocked":
+          case 'blocked':
             return {
-              errorMessage: "위치 정보 접근 권한이 없습니다.",
+              errorMessage: '위치 정보 접근 권한이 없습니다.',
             };
-          case "notSupport":
+          case 'notSupport':
             return {
-              errorMessage: "이 브라우저는 위치 정보 기능을 지원하지 않습니다.",
+              errorMessage: '이 브라우저는 위치 정보 기능을 지원하지 않습니다.',
             };
           default:
             return { errorMessage: error.message };
@@ -59,7 +69,7 @@ export default class MapService {
 
   async initializeMap(container: HTMLDivElement, currentPosition: MapPosition) {
     if (!this.mapController) {
-      throw new Error("mapController is not set");
+      throw new Error('mapController is not set');
     }
 
     const map = await this.mapController.createMap(container, currentPosition);
@@ -68,10 +78,10 @@ export default class MapService {
 
   async addMarkersWithClustering(
     positions: MapPosition[],
-    markerImageSrc: string
+    markerImageSrc: string,
   ) {
     if (!this.mapController) {
-      throw new Error("mapController is not set");
+      throw new Error('mapController is not set');
     }
 
     this.mapController.createMarkersWithClusterer(positions, markerImageSrc);

--- a/packages/usecase/src/storeService.ts
+++ b/packages/usecase/src/storeService.ts
@@ -12,7 +12,7 @@ export default class StoreService {
     authRepository,
     storeRepository,
   }: {
-    authRepository?: AuthRepository;
+    authRepository: AuthRepository;
     storeRepository: StoreRepository;
   }) {
     this.authRepository = authRepository ?? null;
@@ -78,6 +78,10 @@ export default class StoreService {
   }
 
   async getUserSavedStore(userId: number) {
+    if (!this.authRepository) {
+      throw new Error('authRepository is not set');
+    }
+
     if (!this.storeRepository) {
       throw new Error('storeRepository is not set');
     }

--- a/packages/usecase/src/storeService.ts
+++ b/packages/usecase/src/storeService.ts
@@ -5,17 +5,9 @@ import type {
   StoreSummaryData,
 } from '@repo/entity/src/store';
 export default class StoreService {
-  private readonly authRepository: AuthRepository | null;
   private readonly storeRepository: StoreRepository | null;
 
-  constructor({
-    authRepository,
-    storeRepository,
-  }: {
-    authRepository: AuthRepository;
-    storeRepository: StoreRepository;
-  }) {
-    this.authRepository = authRepository ?? null;
+  constructor({ storeRepository }: { storeRepository: StoreRepository }) {
     this.storeRepository = storeRepository ?? null;
   }
 
@@ -77,16 +69,10 @@ export default class StoreService {
     return response;
   }
 
-  async getUserSavedStore(userId: number) {
-    if (!this.authRepository) {
-      throw new Error('authRepository is not set');
-    }
-
+  async getUserSavedStore(authorization: string, userId: number) {
     if (!this.storeRepository) {
       throw new Error('storeRepository is not set');
     }
-
-    const authorization = await this.authRepository.getAuthorization();
 
     const reqestData = {
       data: {

--- a/packages/usecase/src/storeService.ts
+++ b/packages/usecase/src/storeService.ts
@@ -4,7 +4,7 @@ import type {
   StoreRepository,
   StoreSummaryData,
 } from '@repo/entity/src/store';
-export default class storeService {
+export default class StoreService {
   private readonly authRepository: AuthRepository | null;
   private readonly storeRepository: StoreRepository | null;
 
@@ -27,7 +27,7 @@ export default class storeService {
     latitude: number;
     longitude: number;
     radius: number;
-  }): Promise<StoreMapData> {
+  }): Promise<StoreMapData[]> {
     if (!this.storeRepository) {
       throw new Error('storeRepository is not set');
     }

--- a/packages/usecase/src/storeService.ts
+++ b/packages/usecase/src/storeService.ts
@@ -86,7 +86,7 @@ export default class StoreService {
       throw new Error('storeRepository is not set');
     }
 
-    const authorization = await this.authRepository?.getAuthorization();
+    const authorization = await this.authRepository.getAuthorization();
 
     const reqestData = {
       data: {

--- a/packages/usecase/src/storeService.ts
+++ b/packages/usecase/src/storeService.ts
@@ -1,0 +1,118 @@
+import type { AuthRepository } from '@repo/entity/src/auth';
+import type {
+  StoreMapData,
+  StoreRepository,
+  StoreSummaryData,
+} from '@repo/entity/src/store';
+export default class storeService {
+  private readonly authRepository: AuthRepository | null;
+  private readonly storeRepository: StoreRepository | null;
+
+  constructor({
+    authRepository,
+    storeRepository,
+  }: {
+    authRepository?: AuthRepository;
+    storeRepository: StoreRepository;
+  }) {
+    this.authRepository = authRepository ?? null;
+    this.storeRepository = storeRepository ?? null;
+  }
+
+  async getNearbyStores({
+    latitude,
+    longitude,
+    radius,
+  }: {
+    latitude: number;
+    longitude: number;
+    radius: number;
+  }): Promise<StoreMapData> {
+    if (!this.storeRepository) {
+      throw new Error('storeRepository is not set');
+    }
+
+    const requestData = {
+      data: {
+        latitude,
+        longitude,
+        radius,
+      },
+    };
+
+    const response = await this.storeRepository.getNearbyStores(requestData);
+
+    return response;
+  }
+
+  async getStoreSummary(storeId: number): Promise<StoreSummaryData> {
+    if (!this.storeRepository) {
+      throw new Error('storeRepository is not set');
+    }
+
+    const requestData = {
+      data: {
+        storeId,
+      },
+    };
+
+    const response = await this.storeRepository.getStoreSummary(requestData);
+
+    return response;
+  }
+
+  async getStoreDetail(storeId: number) {
+    if (!this.storeRepository) {
+      throw new Error('storeRepository is not set');
+    }
+
+    const requestData = {
+      data: {
+        storeId,
+      },
+    };
+
+    const response = await this.storeRepository.getStoreDetail(requestData);
+
+    return response;
+  }
+
+  async getUserSavedStore(userId: number) {
+    if (!this.storeRepository) {
+      throw new Error('storeRepository is not set');
+    }
+
+    const authorization = await this.authRepository?.getAuthorization();
+
+    const reqestData = {
+      data: {
+        userId,
+      },
+    };
+
+    const result = await this.storeRepository.getUserSavedStore({
+      authorization,
+      ...reqestData,
+    });
+
+    return result;
+  }
+
+  async registerStore() {
+    if (!this.storeRepository) {
+      throw new Error('storeRepository is not set');
+    }
+  }
+
+  async updateStore() {
+    if (!this.storeRepository) {
+      throw new Error('storeRepository is not set');
+    }
+  }
+
+  async deleteStore() {
+    if (!this.storeRepository) {
+      throw new Error('storeRepository is not set');
+    }
+  }
+}


### PR DESCRIPTION
### Summary 
- 가게 관련 entity, repository, service 작성
- mock 데이터 작성
- msw 에러
  - redirect하면 mock service worker 정상 작동 하지 않음
    - middleware에 pathnameHasLocale에 따라 해당 locale 붙여 redirect 되고 있는 상황
    - config matcher에 mockServiceWorker.js 추가
    - 해당 내용 [Next.js15 - MSW issue](https://github.com/swyp-season8-4-team/frontend/issues/9#issue-2803613724)에 추가
  -  Next.js의 스택 트레이스를 위한 내부 요청 (/__nextjs_original-stack-frame)을 MSW가 가로채는 문제
    - 미처리 요청 무시하도록 옵션 설정 (MSW가 모킹하도록 명시적으로 설정한 API 요청들만 가로챔)
      ```javascript
        const { worker } = await import('./browser');
        await worker.start({
          onUnhandledRequest: 'bypass' // 모든 미처리 요청 무시
        });
      ```
  - MockInitializer가 아니라 MockProvider 형태로 바꿈 - Next - MSW 간 렌더링 시점 이슈 해결 위해
  - initMSW는 initServerMSW로 변경, MockProvider에 client 책임 몰아둠
- dev로 실행하면 현재 api에 해당 파라미터에 해당하는데이터가 없기 때문에 실패뜸
  - apps/desserbee-web으로 이동 후 `pmpm dev:test` 실행해야 제대로 나옵니다.
  ```
    apps/desserbee-web$ pmpm dev:test
  ```