### PR TITLE
[map] fix: 카카오맵 페이지 라우팅 시 지도 미표시 문제 해결

### DIFF
--- a/packages/design-system/src/components/BottomSheet/index.tsx
+++ b/packages/design-system/src/components/BottomSheet/index.tsx
@@ -69,7 +69,7 @@ export function BottomSheet({
           >
             <div>
               <div className="w-full flex justify-center items-center">
-                <div className="border-[3px] rounded-[5px] w-[115.5px] border-[#545454] mb-[21px]"></div>
+                <div className="border-[3px] rounded-[5px] w-[115.5px] h- border-[#545454] mb-[21px]"></div>
               </div>
               {children}
             </div>

--- a/packages/entity/src/map.ts
+++ b/packages/entity/src/map.ts
@@ -21,4 +21,5 @@ export interface MapController {
     markerImageSrc: string,
     handleMarkerClick: (storeId: number) => void,
   ): void;
+  destroyMap(): void;
 }

--- a/packages/infrastructures/src/controllers/kakaoMapController.ts
+++ b/packages/infrastructures/src/controllers/kakaoMapController.ts
@@ -131,4 +131,10 @@ export default class KakaoMapController implements MapController {
     // 클러스터러에 마커들을 추가
     clusterer.addMarkers(markers);
   }
+
+  destroyMap() {
+    if (this.map) {
+      this.map = null;
+    }
+  }
 }

--- a/packages/usecase/src/mapService.ts
+++ b/packages/usecase/src/mapService.ts
@@ -80,4 +80,12 @@ export default class MapService {
       handleMakerClick,
     );
   }
+
+  destroyMap() {
+    if (!this.mapController) {
+      throw new Error('mapController is not set');
+    }
+
+    this.mapController.destroyMap();
+  }
 }


### PR DESCRIPTION
### Summary
- 맵 초기화 로직을 별도 함수로 분리
- 컴포넌트 마운트와 스크립트 로드 시점에 맵 초기화 처리
- 컴포넌트 언마운트 시 맵 인스턴스 정리

