### PR TITLE
[draft] [map] feat: 실시간 위치 마커 구현

### DIFF
--- a/apps/desserbee-web/src/app/[lang]/(user)/(search)/_hooks/useMap.ts
+++ b/apps/desserbee-web/src/app/[lang]/(user)/(search)/_hooks/useMap.ts
@@ -1,0 +1,96 @@
+import { useRef, useState } from 'react';
+
+import markerImage from '@/app/[lang]/(user)/(search)/map/_assets/svg/icon-marker.svg';
+import currentMarkerImage from '@/app/[lang]/(user)/(search)/map/_assets/svg/icon-current-marker.svg';
+
+import GeolocationService from '@repo/usecase/src/geolocationService';
+import MapService from '@repo/usecase/src/mapService';
+import StoreService from '@repo/usecase/src/storeService';
+
+import KakaoMapController from '@repo/infrastructures/src/controllers/kakaoMapController';
+import GeolocationController from '@repo/infrastructures/src/controllers/geolocationController';
+import StoreAPIReopository from '@repo/infrastructures/src/repositories/storeAPIRepository';
+
+import { KalmanLocationFilter } from '@repo/infrastructures/src/filters/locationFilter';
+import { MovingAverageFilter } from '@repo/infrastructures/src/filters/movingAverageFilter';
+import type { MapPosition } from '@repo/entity/src/map';
+
+export const useMap = (handleMakerClick: (storeId: number) => void) => {
+  const mapRef = useRef<HTMLDivElement>(null);
+  const mapService = new MapService({
+    mapController: new KakaoMapController(),
+  });
+
+  const geoService = new GeolocationService({
+    geolocationController: new GeolocationController(
+      new KalmanLocationFilter(),
+      new MovingAverageFilter(3),
+    ),
+  });
+  const storeService = new StoreService({
+    storeRepository: new StoreAPIReopository(),
+  });
+
+  const [errorMessage, setErrorMessage] = useState<string>();
+
+  const KAKAO_MAP_API_URL = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_API_KEY}&libraries=services,clusterer&autoload=false`;
+
+  const loadMap = async () => {
+    const container = mapRef.current;
+    if (!container) return;
+
+    try {
+      const result = await geoService.getCurrentPosition();
+
+      if ('errorMessage' in result) {
+        setErrorMessage(result.errorMessage as string); // geoLocation error
+        return;
+      }
+
+      await mapService.initializeMap(container, result);
+
+      await mapService.addCurrentPositionMaker(result, currentMarkerImage.src);
+
+      const storeMapData = await storeService.getNearbyStores({
+        latitude: result.latitude,
+        longitude: result.longitude,
+        radius: 2,
+      });
+
+      await mapService.addMarkersWithClustering(
+        storeMapData,
+        markerImage.src,
+        handleMakerClick,
+      );
+    } catch (error) {
+      if (error instanceof Error) {
+        setErrorMessage(error.message);
+      }
+    }
+  };
+
+  const onSuccess = async (position: MapPosition) => {
+    try {
+      await mapService.addCurrentPositionMaker(
+        position,
+        currentMarkerImage.src,
+      );
+    } catch (error) {
+      if (error instanceof Error) {
+        setErrorMessage(error.message);
+      }
+    }
+  };
+
+  const updateUserPosition = async () => {
+    geoService.startWatchingPosition(onSuccess);
+  };
+
+  return {
+    mapRef,
+    errorMessage,
+    apiUrl: KAKAO_MAP_API_URL,
+    loadMap,
+    updateUserPosition,
+  };
+};

--- a/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/_assets/svg/icon-current-marker.svg
+++ b/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/_assets/svg/icon-current-marker.svg
@@ -1,0 +1,4 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="9" cy="9" r="8.15" fill="white" stroke="#D2D2D2" stroke-width="0.3"/>
+<circle cx="9" cy="9" r="6" fill="#FF5B28"/>
+</svg>

--- a/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/_components/main/KakaoMap/index.tsx
+++ b/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/_components/main/KakaoMap/index.tsx
@@ -6,6 +6,7 @@ import Script from 'next/script';
 import markerImage from '@/app/[lang]/(user)/(search)/map/_assets/svg/icon-marker.svg';
 import currentMarkerImage from '@/app/[lang]/(user)/(search)/map/_assets/svg/icon-current-marker.svg';
 
+import GeolocationService from '@repo/usecase/src/geolocationService';
 import MapService from '@repo/usecase/src/mapService';
 import StoreService from '@repo/usecase/src/storeService';
 
@@ -24,6 +25,9 @@ export function KakaoMap({ children, handleMakerClick }: KakoMapProps) {
   const mapRef = useRef<HTMLDivElement>(null);
   const mapService = new MapService({
     mapController: new KakaoMapController(),
+  });
+
+  const geoService = new GeolocationService({
     geolocationController: new GeolocationController(
       new KalmanLocationFilter(),
       new MovingAverageFilter(3),
@@ -41,7 +45,7 @@ export function KakaoMap({ children, handleMakerClick }: KakoMapProps) {
     if (!container) return;
 
     try {
-      const result = await mapService.getInitialPosition();
+      const result = await geoService.getCurrentPosition();
 
       if ('errorMessage' in result) {
         setErrorMessage(result.errorMessage as string); // geoLocation error
@@ -70,7 +74,7 @@ export function KakaoMap({ children, handleMakerClick }: KakoMapProps) {
 
   const updateUserPosition = async () => {
     try {
-      const result = await mapService.getcurrentPosition();
+      const result = await geoService.getCurrentPosition();
       if ('errorMessage' in result) {
         setErrorMessage(result.errorMessage as string);
         return;

--- a/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/_components/main/KakaoMap/index.tsx
+++ b/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/_components/main/KakaoMap/index.tsx
@@ -13,8 +13,8 @@ import KakaoMapController from '@repo/infrastructures/src/controllers/kakaoMapCo
 import GeolocationController from '@repo/infrastructures/src/controllers/geolocationController';
 import StoreAPIReopository from '@repo/infrastructures/src/repositories/storeAPIRepository';
 
-import { KalmanLocationFilter } from '@repo/infrastructures/src/filters/LocationFilter';
-import { MovingAverageFilter } from '@repo/infrastructures/src/filters/MovingAverageFilter';
+import { KalmanLocationFilter } from '@repo/infrastructures/src/filters/locationFilter';
+import { MovingAverageFilter } from '@repo/infrastructures/src/filters/movingAverageFilter';
 
 interface KakoMapProps {
   children: ReactNode;

--- a/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/_components/main/KakaoMap/index.tsx
+++ b/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/_components/main/KakaoMap/index.tsx
@@ -54,13 +54,15 @@ export function KakaoMap({ children, handleMakerClick }: KakoMapProps) {
 
       await mapService.initializeMap(container, result);
 
+      await mapService.addCurrentPositionMaker(result, currentMarkerImage.src);
+
       const storeMapData = await storeService.getNearbyStores({
         latitude: result.latitude,
         longitude: result.longitude,
         radius: 2,
       });
 
-      mapService.addMarkersWithClustering(
+      await mapService.addMarkersWithClustering(
         storeMapData,
         markerImage.src,
         handleMakerClick,
@@ -96,7 +98,6 @@ export function KakaoMap({ children, handleMakerClick }: KakoMapProps) {
         onReady={() => {
           window.kakao.maps.load(async () => {
             await loadMap();
-            await updateUserPosition();
           });
         }}
       />

--- a/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/_components/main/KakaoMap/index.tsx
+++ b/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/_components/main/KakaoMap/index.tsx
@@ -1,103 +1,30 @@
 'use client';
 
-import { useRef, useState, type ReactNode } from 'react';
+import type { WithChildren } from '@repo/ui/index';
 import Script from 'next/script';
+import type { RefObject } from 'react';
 
-import markerImage from '@/app/[lang]/(user)/(search)/map/_assets/svg/icon-marker.svg';
-import currentMarkerImage from '@/app/[lang]/(user)/(search)/map/_assets/svg/icon-current-marker.svg';
-
-import GeolocationService from '@repo/usecase/src/geolocationService';
-import MapService from '@repo/usecase/src/mapService';
-import StoreService from '@repo/usecase/src/storeService';
-
-import KakaoMapController from '@repo/infrastructures/src/controllers/kakaoMapController';
-import GeolocationController from '@repo/infrastructures/src/controllers/geolocationController';
-import StoreAPIReopository from '@repo/infrastructures/src/repositories/storeAPIRepository';
-
-import { KalmanLocationFilter } from '@repo/infrastructures/src/filters/locationFilter';
-import { MovingAverageFilter } from '@repo/infrastructures/src/filters/movingAverageFilter';
-import type { MapPosition } from '@repo/entity/src/map';
-
-interface KakoMapProps {
-  children: ReactNode;
-  handleMakerClick: (storeId: number) => void;
+interface KakoMapProps extends WithChildren {
+  mapRef: RefObject<HTMLDivElement | null>;
+  errorMessage: string | undefined;
+  apiUrl: string;
+  loadMap: () => Promise<void>;
+  updateUserPosition: () => Promise<void>;
 }
-export function KakaoMap({ children, handleMakerClick }: KakoMapProps) {
-  const mapRef = useRef<HTMLDivElement>(null);
-  const mapService = new MapService({
-    mapController: new KakaoMapController(),
-  });
-
-  const geoService = new GeolocationService({
-    geolocationController: new GeolocationController(
-      new KalmanLocationFilter(),
-      new MovingAverageFilter(3),
-    ),
-  });
-  const storeService = new StoreService({
-    storeRepository: new StoreAPIReopository(),
-  });
-
-  const [errorMessage, setErrorMessage] = useState<string>();
-  const KAKAO_MAP_API_URL = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_API_KEY}&libraries=services,clusterer&autoload=false`;
-
-  const loadMap = async () => {
-    const container = mapRef.current;
-    if (!container) return;
-
-    try {
-      const result = await geoService.getCurrentPosition();
-
-      if ('errorMessage' in result) {
-        setErrorMessage(result.errorMessage as string); // geoLocation error
-        return;
-      }
-
-      await mapService.initializeMap(container, result);
-
-      await mapService.addCurrentPositionMaker(result, currentMarkerImage.src);
-
-      const storeMapData = await storeService.getNearbyStores({
-        latitude: result.latitude,
-        longitude: result.longitude,
-        radius: 2,
-      });
-
-      await mapService.addMarkersWithClustering(
-        storeMapData,
-        markerImage.src,
-        handleMakerClick,
-      );
-    } catch (error) {
-      if (error instanceof Error) {
-        setErrorMessage(error.message);
-      }
-    }
-  };
-
-  const onSuccess = async (position: MapPosition) => {
-    try {
-      await mapService.addCurrentPositionMaker(
-        position,
-        currentMarkerImage.src,
-      );
-    } catch (error) {
-      if (error instanceof Error) {
-        setErrorMessage(error.message);
-      }
-    }
-  };
-
-  const updateUserPosition = async () => {
-    geoService.startWatchingPosition(onSuccess);
-  };
-
+export function KakaoMap({
+  mapRef,
+  children,
+  apiUrl,
+  loadMap,
+  updateUserPosition,
+  errorMessage,
+}: KakoMapProps) {
   return (
     <div>
       <Script
         type="text/javascript"
         async
-        src={KAKAO_MAP_API_URL}
+        src={apiUrl}
         onReady={() => {
           window.kakao.maps.load(async () => {
             await loadMap();

--- a/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/_components/main/KakaoMap/index.tsx
+++ b/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/_components/main/KakaoMap/index.tsx
@@ -36,6 +36,10 @@ export function KakaoMap({
         onReady={() => {
           window.kakao.maps.load(async () => {
             await loadMap();
+          });
+        }}
+        onLoad={() => {
+          window.kakao.maps.load(async () => {
             await startTracking();
           });
         }}

--- a/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/_components/main/KakaoMap/index.tsx
+++ b/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/_components/main/KakaoMap/index.tsx
@@ -36,10 +36,6 @@ export function KakaoMap({
         onReady={() => {
           window.kakao.maps.load(async () => {
             await loadMap();
-          });
-        }}
-        onLoad={() => {
-          window.kakao.maps.load(async () => {
             await startTracking();
           });
         }}

--- a/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/_components/main/KakaoMap/index.tsx
+++ b/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/_components/main/KakaoMap/index.tsx
@@ -16,6 +16,7 @@ import StoreAPIReopository from '@repo/infrastructures/src/repositories/storeAPI
 
 import { KalmanLocationFilter } from '@repo/infrastructures/src/filters/locationFilter';
 import { MovingAverageFilter } from '@repo/infrastructures/src/filters/movingAverageFilter';
+import type { MapPosition } from '@repo/entity/src/map';
 
 interface KakoMapProps {
   children: ReactNode;
@@ -74,19 +75,21 @@ export function KakaoMap({ children, handleMakerClick }: KakoMapProps) {
     }
   };
 
-  const updateUserPosition = async () => {
+  const onSuccess = async (position: MapPosition) => {
     try {
-      const result = await geoService.getCurrentPosition();
-      if ('errorMessage' in result) {
-        setErrorMessage(result.errorMessage as string);
-        return;
-      }
-      await mapService.addCurrentPositionMaker(result, currentMarkerImage.src);
+      await mapService.addCurrentPositionMaker(
+        position,
+        currentMarkerImage.src,
+      );
     } catch (error) {
       if (error instanceof Error) {
         setErrorMessage(error.message);
       }
     }
+  };
+
+  const updateUserPosition = async () => {
+    geoService.startWatchingPosition(onSuccess);
   };
 
   return (
@@ -98,6 +101,7 @@ export function KakaoMap({ children, handleMakerClick }: KakoMapProps) {
         onReady={() => {
           window.kakao.maps.load(async () => {
             await loadMap();
+            await updateUserPosition();
           });
         }}
       />

--- a/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/_components/main/KakaoMap/index.tsx
+++ b/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/_components/main/KakaoMap/index.tsx
@@ -91,8 +91,8 @@ export function KakaoMap({ children, handleMakerClick }: KakoMapProps) {
         src={KAKAO_MAP_API_URL}
         onReady={() => {
           window.kakao.maps.load(async () => {
-            loadMap();
-            updateUserPosition();
+            await loadMap();
+            await updateUserPosition();
           });
         }}
       />

--- a/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/_components/main/KakaoMap/index.tsx
+++ b/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/_components/main/KakaoMap/index.tsx
@@ -9,7 +9,7 @@ interface KakoMapProps extends WithChildren {
   errorMessage: string | undefined;
   apiUrl: string;
   loadMap: () => Promise<void>;
-  updateUserPosition: () => Promise<void>;
+  startTracking: () => Promise<void>;
   stopTracking: () => Promise<void>;
 }
 export function KakaoMap({
@@ -18,7 +18,7 @@ export function KakaoMap({
   apiUrl,
   errorMessage,
   loadMap,
-  updateUserPosition,
+  startTracking,
   stopTracking,
 }: KakoMapProps) {
   useEffect(() => {
@@ -36,7 +36,7 @@ export function KakaoMap({
         onReady={() => {
           window.kakao.maps.load(async () => {
             await loadMap();
-            await updateUserPosition();
+            await startTracking();
           });
         }}
       />

--- a/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/_components/main/KakaoMap/index.tsx
+++ b/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/_components/main/KakaoMap/index.tsx
@@ -2,7 +2,7 @@
 
 import type { WithChildren } from '@repo/ui/index';
 import Script from 'next/script';
-import type { RefObject } from 'react';
+import { useEffect, type RefObject } from 'react';
 
 interface KakoMapProps extends WithChildren {
   mapRef: RefObject<HTMLDivElement | null>;
@@ -10,15 +10,23 @@ interface KakoMapProps extends WithChildren {
   apiUrl: string;
   loadMap: () => Promise<void>;
   updateUserPosition: () => Promise<void>;
+  stopTracking: () => Promise<void>;
 }
 export function KakaoMap({
-  mapRef,
   children,
+  mapRef,
   apiUrl,
+  errorMessage,
   loadMap,
   updateUserPosition,
-  errorMessage,
+  stopTracking,
 }: KakoMapProps) {
+  useEffect(() => {
+    return () => {
+      stopTracking();
+    };
+  }, []);
+
   return (
     <div>
       <Script

--- a/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/_components/main/MapPanel/index.tsx
+++ b/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/_components/main/MapPanel/index.tsx
@@ -2,31 +2,12 @@ import { IconSize } from '@repo/design-system/components/icons';
 
 import IconFlowerOutline from '@repo/design-system/components/icons/IconFlowerOutline';
 import IconTarget from '@repo/design-system/components/icons/IconTarget';
-import IconPlus from '@repo/design-system/components/icons/IconPlus';
-import IconMinus from '@repo/design-system/components/icons/IconMinus';
-
-import { useState, type ChangeEvent } from 'react';
 
 interface MapPanelProps {
   handleSideBarOpen: () => void;
 }
 
 export function MapPanel({ handleSideBarOpen }: MapPanelProps) {
-  const [value, setValue] = useState(2.5);
-  const [range] = useState({ min: 0, max: 5 });
-
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setValue(Number(e.target.value));
-  };
-
-  const increment = () => {
-    setValue((prev) => Math.min(prev + 1, range.max));
-  };
-
-  const decrement = () => {
-    setValue((prev) => Math.max(prev - 1, range.min));
-  };
-
   return (
     <div className="absolute w-[47px] aspect-square right-4 bottom-2 z-10 flex flex-col gap-2">
       <button
@@ -38,32 +19,6 @@ export function MapPanel({ handleSideBarOpen }: MapPanelProps) {
       <button className="flex justify-center items-center aspect-square rounded-sm bg-white">
         <IconTarget size={IconSize.m} className="#6F6F6F" />
       </button>
-      <div className="grid grid-rows-[0.3fr_2fr_0.3fr] bg-white rounded-sm">
-        <button
-          className="flex justify-center w-full py-[10px]"
-          onClick={increment}
-        >
-          <IconPlus size={IconSize.xs} className="text-[#6F6F6F]" />
-        </button>
-        <div className="relative h-[200px] border-y-[0.26px] border-y-[#D2D2D2] flex justify-center">
-          <input
-            type="range"
-            value={value}
-            min={range.min}
-            max={range.max}
-            className="absolute appearance-none top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 origin-center -rotate-90
-            [&::-webkit-slider-runnable-track]:w-full [&::-webkit-slider-runnable-track]:h-[6.08px] [&::-webkit-slider-runnable-track]:bg-[#BABABA] 
-            [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:h-[20.86px] [&::-webkit-slider-thumb]:w-[8px] [&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:border-[#9FA3A2] [&::-webkit-slider-thumb]:border-[0.43px] [&::-webkit-slider-thumb]:border-solid [&::-webkit-slider-thumb]:-mt-2 [&::-webkit-slider-thumb]:relative"
-            onChange={handleChange}
-          />
-        </div>
-        <button
-          className="flex justify-center w-full py-[10px]"
-          onClick={decrement}
-        >
-          <IconMinus size={IconSize.xs} className="text-[#6F6F6F]" />
-        </button>
-      </div>
     </div>
   );
 }

--- a/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/_components/main/MapPanel/index.tsx
+++ b/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/_components/main/MapPanel/index.tsx
@@ -2,12 +2,19 @@ import { IconSize } from '@repo/design-system/components/icons';
 
 import IconFlowerOutline from '@repo/design-system/components/icons/IconFlowerOutline';
 import IconTarget from '@repo/design-system/components/icons/IconTarget';
+import { cn } from '@repo/ui/lib/utils';
 
 interface MapPanelProps {
   handleSideBarOpen: () => void;
+  handleTrackingToggle: () => void;
+  isTracking: boolean;
 }
 
-export function MapPanel({ handleSideBarOpen }: MapPanelProps) {
+export function MapPanel({
+  handleSideBarOpen,
+  handleTrackingToggle,
+  isTracking,
+}: MapPanelProps) {
   return (
     <div className="absolute w-[47px] aspect-square right-4 bottom-2 z-10 flex flex-col gap-2">
       <button
@@ -16,7 +23,13 @@ export function MapPanel({ handleSideBarOpen }: MapPanelProps) {
       >
         <IconFlowerOutline size={IconSize.l} className="#6F6F6F" />
       </button>
-      <button className="flex justify-center items-center aspect-square rounded-sm bg-white">
+      <button
+        onClick={handleTrackingToggle}
+        className={cn(
+          isTracking ? 'text-red-600' : '',
+          'flex justify-center items-center aspect-square rounded-sm bg-white',
+        )}
+      >
         <IconTarget size={IconSize.m} className="#6F6F6F" />
       </button>
     </div>

--- a/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/_components/main/MapPanel/index.tsx
+++ b/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/_components/main/MapPanel/index.tsx
@@ -6,14 +6,12 @@ import { cn } from '@repo/ui/lib/utils';
 
 interface MapPanelProps {
   handleSideBarOpen: () => void;
-  handleTrackingToggle: () => void;
-  isTracking: boolean;
+  moveToCurrentPosition: () => void;
 }
 
 export function MapPanel({
   handleSideBarOpen,
-  handleTrackingToggle,
-  isTracking,
+  moveToCurrentPosition,
 }: MapPanelProps) {
   return (
     <div className="absolute w-[47px] aspect-square right-4 bottom-2 z-10 flex flex-col gap-2">
@@ -24,9 +22,8 @@ export function MapPanel({
         <IconFlowerOutline size={IconSize.l} className="#6F6F6F" />
       </button>
       <button
-        onClick={handleTrackingToggle}
+        onClick={moveToCurrentPosition}
         className={cn(
-          isTracking ? 'text-red-600' : '',
           'flex justify-center items-center aspect-square rounded-sm bg-white',
         )}
       >

--- a/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/page.tsx
+++ b/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/page.tsx
@@ -32,10 +32,9 @@ export default function MapPage() {
     errorMessage,
     apiUrl,
     loadMap,
-    isTracking,
     stopTracking,
     startTracking,
-    handleTrackingToggle,
+    moveToCurrentPosition,
   } = useMap(handleMakerClick);
 
   const kakaoMapProps = {
@@ -49,8 +48,7 @@ export default function MapPage() {
 
   const mapPanelProps = {
     handleSideBarOpen,
-    handleTrackingToggle,
-    isTracking,
+    moveToCurrentPosition,
   };
 
   const bottomSheetProps = {

--- a/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/page.tsx
+++ b/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/page.tsx
@@ -12,6 +12,7 @@ import { MapPanel } from './_components/main/MapPanel';
 import { SideBarContainer } from './_components/sidebar/SidebarContainer';
 import { useSideBar } from '../_hooks/useSidebar';
 import { PreferenceTags } from './_components/main/PreferenceTags';
+import { useMap } from '../_hooks/useMap';
 
 export default function MapPage() {
   const [selectedStoreId, setSelectedStoreId] = useState<number>();
@@ -21,11 +22,20 @@ export default function MapPage() {
 
   const { isSideBarOpen, handleSideBarOpen, handleSideBarClose } = useSideBar();
 
+  const handleMakerClick = (storeId: number) => {
+    setSelectedStoreId(storeId);
+    handleBottomSheetOpen();
+  };
+
+  const { mapRef, errorMessage, apiUrl, loadMap, updateUserPosition } =
+    useMap(handleMakerClick);
+
   const kakaoMapProps = {
-    handleMakerClick: (storeId: number) => {
-      setSelectedStoreId(storeId);
-      handleBottomSheetOpen();
-    },
+    mapRef,
+    apiUrl,
+    loadMap,
+    updateUserPosition,
+    errorMessage,
   };
 
   const mapPanelProps = {

--- a/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/page.tsx
+++ b/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/page.tsx
@@ -27,8 +27,16 @@ export default function MapPage() {
     handleBottomSheetOpen();
   };
 
-  const { mapRef, errorMessage, apiUrl, loadMap, updateUserPosition } =
-    useMap(handleMakerClick);
+  const {
+    mapRef,
+    errorMessage,
+    apiUrl,
+    loadMap,
+    updateUserPosition,
+    isTracking,
+    handleTrackingToggle,
+    stopTracking,
+  } = useMap(handleMakerClick);
 
   const kakaoMapProps = {
     mapRef,
@@ -36,10 +44,13 @@ export default function MapPage() {
     loadMap,
     updateUserPosition,
     errorMessage,
+    stopTracking,
   };
 
   const mapPanelProps = {
     handleSideBarOpen,
+    handleTrackingToggle,
+    isTracking,
   };
 
   const bottomSheetProps = {

--- a/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/page.tsx
+++ b/apps/desserbee-web/src/app/[lang]/(user)/(search)/map/page.tsx
@@ -32,19 +32,19 @@ export default function MapPage() {
     errorMessage,
     apiUrl,
     loadMap,
-    updateUserPosition,
     isTracking,
-    handleTrackingToggle,
     stopTracking,
+    startTracking,
+    handleTrackingToggle,
   } = useMap(handleMakerClick);
 
   const kakaoMapProps = {
     mapRef,
+    errorMessage,
     apiUrl,
     loadMap,
-    updateUserPosition,
-    errorMessage,
     stopTracking,
+    startTracking,
   };
 
   const mapPanelProps = {

--- a/apps/desserbee-web/src/mocks/handlers/store-handlers.ts
+++ b/apps/desserbee-web/src/mocks/handlers/store-handlers.ts
@@ -60,20 +60,7 @@ export const storeHandlers = [
       },
     ];
 
-    if (
-      Number(latitude) === 37.498095 &&
-      Number(longitude) === 127.028979 &&
-      Number(radius) === 2
-    ) {
-      return new HttpResponse(JSON.stringify(storeMapDataList), {
-        status: 200,
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      });
-    }
-
-    return new HttpResponse(JSON.stringify([]), {
+    return new HttpResponse(JSON.stringify(storeMapDataList), {
       status: 200,
       headers: {
         'Content-Type': 'application/json',

--- a/packages/entity/src/geolocation.ts
+++ b/packages/entity/src/geolocation.ts
@@ -2,6 +2,9 @@ import type { MapPosition } from './map';
 
 export interface GeolocationController {
   getCurrentPosition(): Promise<MapPosition>;
-  startWatching(options?: PositionOptions): Promise<MapPosition>;
+  startWatching(
+    onSuccess: (position: MapPosition) => void,
+    options?: PositionOptions,
+  ): void;
   stopWatching(): void;
 }

--- a/packages/entity/src/geolocation.ts
+++ b/packages/entity/src/geolocation.ts
@@ -1,0 +1,7 @@
+import type { MapPosition } from './map';
+
+export interface GeolocationController {
+  getCurrentPosition(): Promise<MapPosition>;
+  startWatching(options?: PositionOptions): Promise<MapPosition>;
+  stopWatching(): void;
+}

--- a/packages/entity/src/geolocation.ts
+++ b/packages/entity/src/geolocation.ts
@@ -5,6 +5,6 @@ export interface GeolocationController {
   startWatching(
     onSuccess: (position: MapPosition) => void,
     options?: PositionOptions,
-  ): void;
-  stopWatching(): void;
+  ): Promise<MapPosition>;
+  stopWatching(): Promise<void>;
 }

--- a/packages/entity/src/map.ts
+++ b/packages/entity/src/map.ts
@@ -12,8 +12,18 @@ export interface ExternalMap {
   getLevel(): number;
 }
 
-export interface MapController {
+export interface GeolocationController {
+  getInitialPosition(): Promise<MapPosition>;
   getCurrentPosition(): Promise<MapPosition>;
+  startWatching(
+    onSuccess: (position: MapPosition) => void,
+    onError: (error: GeolocationPositionError) => void,
+    options?: PositionOptions,
+  ): void;
+  stopWatching(): void;
+}
+
+export interface MapController {
   createMap(
     container: HTMLDivElement,
     position: MapPosition,
@@ -23,5 +33,11 @@ export interface MapController {
     markerImageSrc: string,
     handleMarkerClick: (storeId: number) => void,
   ): void;
-  destroyMap(): void;
+  createCurrentPosMarker(position: MapPosition, markerImageSrc: string): void;
+  updateCurrentPositionMarker(
+    position: MapPosition,
+    markerImageSrc: string,
+  ): void;
+  removeCurrentPosMarker(): void;
+  clearAllMarkers(): void;
 }

--- a/packages/entity/src/map.ts
+++ b/packages/entity/src/map.ts
@@ -12,17 +12,6 @@ export interface ExternalMap {
   getLevel(): number;
 }
 
-export interface GeolocationController {
-  getInitialPosition(): Promise<MapPosition>;
-  getCurrentPosition(): Promise<MapPosition>;
-  startWatching(
-    onSuccess: (position: MapPosition) => void,
-    onError: (error: GeolocationPositionError) => void,
-    options?: PositionOptions,
-  ): void;
-  stopWatching(): void;
-}
-
 export interface MapController {
   createMap(
     container: HTMLDivElement,

--- a/packages/entity/src/map.ts
+++ b/packages/entity/src/map.ts
@@ -29,4 +29,5 @@ export interface MapController {
   removeCurrentPositionMarker(): void;
   clearAllMarkers(): void;
   setMapCenter(position: MapPosition): void;
+  relayout(): void;
 }

--- a/packages/entity/src/map.ts
+++ b/packages/entity/src/map.ts
@@ -22,11 +22,11 @@ export interface MapController {
     markerImageSrc: string,
     handleMarkerClick: (storeId: number) => void,
   ): void;
-  createCurrentPosMarker(position: MapPosition, markerImageSrc: string): void;
-  updateCurrentPositionMarker(
+  createCurrentPositionMarker(
     position: MapPosition,
     markerImageSrc: string,
   ): void;
-  removeCurrentPosMarker(): void;
+  removeCurrentPositionMarker(): void;
   clearAllMarkers(): void;
+  setMapCenter(position: MapPosition): void;
 }

--- a/packages/infrastructures/src/adapters/kakaoMapAdapter.ts
+++ b/packages/infrastructures/src/adapters/kakaoMapAdapter.ts
@@ -108,11 +108,7 @@ export class KakaoMapAdapter implements ExternalMap {
     }
   }
 
-  createCurrentPosMarker(position: MapPosition, markerImageSrc: string): void {
-    this.updateCurrentPositionMarker(position, markerImageSrc);
-  }
-
-  updateCurrentPositionMarker(
+  createCurrentPositionMarker(
     position: MapPosition,
     markerImageSrc: string,
   ): void {

--- a/packages/infrastructures/src/adapters/kakaoMapAdapter.ts
+++ b/packages/infrastructures/src/adapters/kakaoMapAdapter.ts
@@ -140,4 +140,8 @@ export class KakaoMapAdapter implements ExternalMap {
       this.currentPosMarker = null;
     }
   }
+
+  relayout(): void {
+    this.relayout();
+  }
 }

--- a/packages/infrastructures/src/adapters/kakaoMapAdapter.ts
+++ b/packages/infrastructures/src/adapters/kakaoMapAdapter.ts
@@ -1,11 +1,24 @@
-import type { ExternalMap, MapPosition } from "@repo/entity/src/map";
+import type { ExternalMap, MapPosition } from '@repo/entity/src/map';
+import type { StoreMapData } from '@repo/entity/src/store';
+
+interface CustomMarker extends kakao.maps.Marker {
+  storeData?: {
+    id: number;
+    name: string;
+    address: string;
+  };
+}
 
 export class KakaoMapAdapter implements ExternalMap {
+  private currentPosMarker: CustomMarker | null = null;
+  private markers: CustomMarker[] = [];
+  private clusterer: kakao.maps.MarkerClusterer | null = null;
+
   constructor(private readonly map: kakao.maps.Map) {}
 
   setCenter(position: MapPosition): void {
     this.map.setCenter(
-      new kakao.maps.LatLng(position.latitude, position.longitude)
+      new kakao.maps.LatLng(position.latitude, position.longitude),
     );
   }
 
@@ -28,5 +41,107 @@ export class KakaoMapAdapter implements ExternalMap {
   // 내부 구현체 접근을 위한 메서드
   getNativeMap(): kakao.maps.Map {
     return this.map;
+  }
+
+  createMarkersWithClusterer(
+    storeMapData: StoreMapData[],
+    markerImageSrc: string,
+    handleMarkerClick: (storeId: number) => void,
+  ): void {
+    this.clearAllMarkers();
+
+    const imageSize = new kakao.maps.Size(24, 24);
+    const markerImage = new kakao.maps.MarkerImage(markerImageSrc, imageSize);
+
+    this.markers = storeMapData.map((store) => {
+      const marker = new kakao.maps.Marker({
+        position: new kakao.maps.LatLng(store.latitude, store.longitude),
+        image: markerImage,
+        map: this.map,
+      }) as CustomMarker;
+
+      marker.storeData = {
+        id: store.id,
+        name: store.name,
+        address: store.address,
+      };
+
+      kakao.maps.event.addListener(marker, 'click', () => {
+        handleMarkerClick(store.id);
+      });
+
+      return marker;
+    });
+
+    this.clusterer = new kakao.maps.MarkerClusterer({
+      map: this.map,
+      averageCenter: true,
+      minLevel: 5,
+    });
+
+    this.clusterer.addMarkers(this.markers);
+  }
+
+  clearAllMarkers(): void {
+    this.markers.forEach((marker) => {
+      marker.setMap(null);
+    });
+    this.markers = [];
+
+    if (this.clusterer) {
+      this.clusterer.clear();
+      this.clusterer = null;
+    }
+  }
+
+  getMarkerById(storeId: number): CustomMarker | undefined {
+    return this.markers.find((marker) => marker.storeData?.id === storeId);
+  }
+
+  removeMarkerById(storeId: number): void {
+    const markerIndex = this.markers.findIndex(
+      (marker) => marker.storeData?.id === storeId,
+    );
+    if (markerIndex !== -1) {
+      this.markers[markerIndex].setMap(null);
+      this.markers.splice(markerIndex, 1);
+    }
+  }
+
+  createCurrentPosMarker(position: MapPosition, markerImageSrc: string): void {
+    this.updateCurrentPositionMarker(position, markerImageSrc);
+  }
+
+  updateCurrentPositionMarker(
+    position: MapPosition,
+    markerImageSrc: string,
+  ): void {
+    if (!this.map) return;
+
+    if (this.currentPosMarker) {
+      this.currentPosMarker.setMap(null);
+    }
+
+    const markerPosition = new kakao.maps.LatLng(
+      position.latitude,
+      position.longitude,
+    );
+
+    const imageSize = new kakao.maps.Size(24, 24);
+    const markerImage = new kakao.maps.MarkerImage(markerImageSrc, imageSize);
+
+    this.currentPosMarker = new kakao.maps.Marker({
+      position: markerPosition,
+      map: this.map,
+      image: markerImage,
+      zIndex: 1,
+    }) as CustomMarker;
+  }
+
+  removeCurrentPositionMarker(): void {
+    if (this.currentPosMarker) {
+      this.currentPosMarker.setMap(null);
+      this.currentPosMarker = null;
+    }
   }
 }

--- a/packages/infrastructures/src/controllers/geolocationController.ts
+++ b/packages/infrastructures/src/controllers/geolocationController.ts
@@ -9,19 +9,41 @@ export default class GeolocationController {
     this.filters = filters;
   }
 
-  getInitialPosition(): Promise<MapPosition> {
+  private applyFilters(
+    position: MapPosition,
+    accuracy: number,
+  ): Promise<MapPosition> | MapPosition {
+    return this.filters.reduce<Promise<MapPosition> | MapPosition>(
+      async (pos, filter) => filter.filter(await pos, accuracy),
+      position,
+    );
+  }
+
+  getCurrentPosition(): Promise<MapPosition> {
     return new Promise((resolve, reject) => {
       if (navigator.geolocation) {
         navigator.geolocation.getCurrentPosition(
           (pos) => {
             if (process.env.NEXT_PUBLIC_USE_API_MOCKING === 'true') {
-              const latitude = 37.498095;
-              const longitude = 127.028979;
-              resolve({ latitude, longitude });
+              // const latitude = 37.498095;
+              // const longitude = 127.028979;
+              const latitude = pos.coords.latitude;
+              const longitude = pos.coords.longitude;
+
+              const position = this.applyFilters(
+                { latitude, longitude },
+                pos.coords.accuracy,
+              );
+
+              resolve(position);
             } else {
               const latitude = pos.coords.latitude;
               const longitude = pos.coords.longitude;
-              resolve({ latitude, longitude });
+              const position = this.applyFilters(
+                { latitude, longitude },
+                pos.coords.accuracy,
+              );
+              resolve(position);
             }
           },
           (err) => {
@@ -34,9 +56,9 @@ export default class GeolocationController {
             reject(err);
           },
           {
-            enableHighAccuracy: false,
-            maximumAge: 180000,
-            timeout: 7000,
+            enableHighAccuracy: true,
+            timeout: 15000,
+            maximumAge: 0,
           },
         );
       } else {
@@ -45,66 +67,40 @@ export default class GeolocationController {
     });
   }
 
-  private applyFilters(position: MapPosition, accuracy: number): MapPosition {
-    return this.filters.reduce(
-      (pos, filter) => filter.filter(pos, accuracy),
-      position,
-    );
-  }
-
-  getCurrentPosition(): Promise<MapPosition> {
+  startWatching(options?: PositionOptions): Promise<MapPosition> {
     return new Promise((resolve, reject) => {
-      if (!navigator.geolocation) {
-        reject(new Error('notSupport'));
-        return;
+      if (navigator.geolocation) {
+        this.watchId = navigator.geolocation.watchPosition(
+          (pos) => {
+            const position = {
+              latitude: pos.coords.latitude,
+              longitude: pos.coords.longitude,
+            };
+            resolve(this.applyFilters(position, pos.coords.accuracy));
+          },
+          (err) => {
+            if (err.code === 3) {
+              reject(new Error('delayed'));
+            }
+            if (err.code === 1) {
+              reject(new Error('blocked'));
+            }
+            reject(err);
+          },
+          {
+            ...options,
+            enableHighAccuracy: true, // 높은 정확도
+            timeout: 15000, // 위치를 가져오는 제한 시간
+            maximumAge: 0, // 캐시된 위치 정보를 사용하지 않음
+          },
+        );
       }
-
-      navigator.geolocation.getCurrentPosition(
-        (pos) => {
-          const position = {
-            latitude: pos.coords.latitude,
-            longitude: pos.coords.longitude,
-          };
-          resolve(this.applyFilters(position, pos.coords.accuracy));
-        },
-        (err) => reject(new Error(err.message)),
-        {
-          enableHighAccuracy: true,
-          timeout: 15000,
-          maximumAge: 0,
-        },
-      );
     });
-  }
-
-  startWatching(
-    onSuccess: (position: MapPosition) => void,
-    onError: (error: GeolocationPositionError) => void,
-    options?: PositionOptions,
-  ): void {
-    if (navigator.geolocation) {
-      this.watchId = navigator.geolocation.watchPosition(
-        (pos) => {
-          const position = {
-            latitude: pos.coords.latitude,
-            longitude: pos.coords.longitude,
-          };
-          onSuccess(this.applyFilters(position, pos.coords.accuracy));
-        },
-        onError,
-        {
-          enableHighAccuracy: true,
-          timeout: 15000,
-          maximumAge: 0,
-          ...options,
-        },
-      );
-    }
   }
 
   stopWatching(): void {
     if (this.watchId !== null) {
-      navigator.geolocation.clearWatch(this.watchId);
+      navigator.geolocation.clearWatch(this.watchId); // 위치 추적을 중지
       this.watchId = null;
     }
   }

--- a/packages/infrastructures/src/controllers/geolocationController.ts
+++ b/packages/infrastructures/src/controllers/geolocationController.ts
@@ -67,41 +67,47 @@ export default class GeolocationController {
   startWatching(
     onSuccess: (position: MapPosition) => void,
     options?: PositionOptions,
-  ): void {
-    if (navigator.geolocation) {
-      this.watchId = navigator.geolocation.watchPosition(
-        (pos) => {
-          const latitude = pos.coords.latitude;
-          const longitude = pos.coords.longitude;
-          const position = this.applyFilters(
-            { latitude, longitude },
-            pos.coords.accuracy,
-          );
+  ): Promise<MapPosition> {
+    return new Promise<MapPosition>((resolve, reject) => {
+      if (navigator.geolocation) {
+        this.watchId = navigator.geolocation.watchPosition(
+          (pos) => {
+            const latitude = pos.coords.latitude;
+            const longitude = pos.coords.longitude;
+            const position = this.applyFilters(
+              { latitude, longitude },
+              pos.coords.accuracy,
+            );
 
-          onSuccess(position);
-        },
-        (err) => {
-          if (err.code === 3) {
-            new Error('watching 지연');
-          }
-          if (err.code === 1) {
-            new Error('watching 중단');
-          }
-        },
-        {
-          ...options,
-          enableHighAccuracy: true,
-          timeout: 15000,
-          maximumAge: 0,
-        },
-      );
-    }
+            onSuccess(position);
+            resolve(position);
+          },
+          (err) => {
+            if (err.code === 3) {
+              new Error('watching 지연');
+            }
+            if (err.code === 1) {
+              new Error('watching 중단');
+            }
+          },
+          {
+            ...options,
+            enableHighAccuracy: true,
+            timeout: 1500,
+            maximumAge: 0,
+          },
+        );
+      }
+    });
   }
 
-  stopWatching(): void {
-    if (this.watchId !== null) {
-      navigator.geolocation.clearWatch(this.watchId); // 위치 추적을 중지
-      this.watchId = null;
-    }
+  stopWatching(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      if (this.watchId !== null) {
+        navigator.geolocation.clearWatch(this.watchId); // 위치 추적을 중지
+        this.watchId = null;
+        resolve();
+      }
+    });
   }
 }

--- a/packages/infrastructures/src/controllers/geolocationController.ts
+++ b/packages/infrastructures/src/controllers/geolocationController.ts
@@ -72,11 +72,13 @@ export default class GeolocationController {
       if (navigator.geolocation) {
         this.watchId = navigator.geolocation.watchPosition(
           (pos) => {
-            const position = {
-              latitude: pos.coords.latitude,
-              longitude: pos.coords.longitude,
-            };
-            resolve(this.applyFilters(position, pos.coords.accuracy));
+            const latitude = pos.coords.latitude;
+            const longitude = pos.coords.longitude;
+            const position = this.applyFilters(
+              { latitude, longitude },
+              pos.coords.accuracy,
+            );
+            resolve(position);
           },
           (err) => {
             if (err.code === 3) {

--- a/packages/infrastructures/src/controllers/geolocationController.ts
+++ b/packages/infrastructures/src/controllers/geolocationController.ts
@@ -1,0 +1,111 @@
+import type { MapPosition } from '@repo/entity/src/map';
+import type { LocationFilter } from '../filters/locationFilter';
+
+export default class GeolocationController {
+  private watchId: number | null = null;
+  private readonly filters: LocationFilter[];
+
+  constructor(...filters: LocationFilter[]) {
+    this.filters = filters;
+  }
+
+  getInitialPosition(): Promise<MapPosition> {
+    return new Promise((resolve, reject) => {
+      if (navigator.geolocation) {
+        navigator.geolocation.getCurrentPosition(
+          (pos) => {
+            if (process.env.NEXT_PUBLIC_USE_API_MOCKING === 'true') {
+              const latitude = 37.498095;
+              const longitude = 127.028979;
+              resolve({ latitude, longitude });
+            } else {
+              const latitude = pos.coords.latitude;
+              const longitude = pos.coords.longitude;
+              resolve({ latitude, longitude });
+            }
+          },
+          (err) => {
+            if (err.code === 3) {
+              reject(new Error('delayed'));
+            }
+            if (err.code === 1) {
+              reject(new Error('blocked'));
+            }
+            reject(err);
+          },
+          {
+            enableHighAccuracy: false,
+            maximumAge: 180000,
+            timeout: 7000,
+          },
+        );
+      } else {
+        reject(new Error('notSupport'));
+      }
+    });
+  }
+
+  private applyFilters(position: MapPosition, accuracy: number): MapPosition {
+    return this.filters.reduce(
+      (pos, filter) => filter.filter(pos, accuracy),
+      position,
+    );
+  }
+
+  getCurrentPosition(): Promise<MapPosition> {
+    return new Promise((resolve, reject) => {
+      if (!navigator.geolocation) {
+        reject(new Error('notSupport'));
+        return;
+      }
+
+      navigator.geolocation.getCurrentPosition(
+        (pos) => {
+          const position = {
+            latitude: pos.coords.latitude,
+            longitude: pos.coords.longitude,
+          };
+          resolve(this.applyFilters(position, pos.coords.accuracy));
+        },
+        (err) => reject(new Error(err.message)),
+        {
+          enableHighAccuracy: true,
+          timeout: 15000,
+          maximumAge: 0,
+        },
+      );
+    });
+  }
+
+  startWatching(
+    onSuccess: (position: MapPosition) => void,
+    onError: (error: GeolocationPositionError) => void,
+    options?: PositionOptions,
+  ): void {
+    if (navigator.geolocation) {
+      this.watchId = navigator.geolocation.watchPosition(
+        (pos) => {
+          const position = {
+            latitude: pos.coords.latitude,
+            longitude: pos.coords.longitude,
+          };
+          onSuccess(this.applyFilters(position, pos.coords.accuracy));
+        },
+        onError,
+        {
+          enableHighAccuracy: true,
+          timeout: 15000,
+          maximumAge: 0,
+          ...options,
+        },
+      );
+    }
+  }
+
+  stopWatching(): void {
+    if (this.watchId !== null) {
+      navigator.geolocation.clearWatch(this.watchId);
+      this.watchId = null;
+    }
+  }
+}

--- a/packages/infrastructures/src/controllers/kakaoMapController.ts
+++ b/packages/infrastructures/src/controllers/kakaoMapController.ts
@@ -87,4 +87,12 @@ export default class KakaoMapController implements MapController {
 
     this.map.setCenter(position);
   }
+
+  relayout(): void {
+    if (!this.map) {
+      throw new Error('Map is not initialized');
+    }
+
+    this.map.relayout();
+  }
 }

--- a/packages/infrastructures/src/controllers/kakaoMapController.ts
+++ b/packages/infrastructures/src/controllers/kakaoMapController.ts
@@ -60,15 +60,7 @@ export default class KakaoMapController implements MapController {
     return this.map.getMarkerById(storeId);
   }
 
-  createCurrentPosMarker(position: MapPosition, markerImageSrc: string): void {
-    if (!this.map) {
-      throw new Error('Map is not initialized');
-    }
-
-    this.map.createCurrentPosMarker(position, markerImageSrc);
-  }
-
-  updateCurrentPositionMarker(
+  createCurrentPositionMarker(
     position: MapPosition,
     markerImageSrc: string,
   ): void {
@@ -76,14 +68,23 @@ export default class KakaoMapController implements MapController {
       throw new Error('Map is not initialized');
     }
 
-    this.map.updateCurrentPositionMarker(position, markerImageSrc);
+    this.map.createCurrentPositionMarker(position, markerImageSrc);
+    this.map.setCenter(position);
   }
 
-  removeCurrentPosMarker(): void {
+  removeCurrentPositionMarker(): void {
     if (!this.map) {
       throw new Error('Map is not initialized');
     }
 
     this.map.removeCurrentPositionMarker();
+  }
+
+  setMapCenter(position: MapPosition) {
+    if (!this.map) {
+      throw new Error('Map is not initialized');
+    }
+
+    this.map.setCenter(position);
   }
 }

--- a/packages/infrastructures/src/controllers/kakaoMapController.ts
+++ b/packages/infrastructures/src/controllers/kakaoMapController.ts
@@ -22,6 +22,7 @@ export default class KakaoMapController implements MapController {
     });
 
     const zoomControl = new kakao.maps.ZoomControl();
+
     kakaoMap.addControl(zoomControl, kakao.maps.ControlPosition.BOTTOMRIGHT);
 
     this.map = new KakaoMapAdapter(kakaoMap);

--- a/packages/infrastructures/src/controllers/kakaoMapController.ts
+++ b/packages/infrastructures/src/controllers/kakaoMapController.ts
@@ -22,7 +22,7 @@ export default class KakaoMapController implements MapController {
     });
 
     const zoomControl = new kakao.maps.ZoomControl();
-    // kakaoMap.addControl(zoomControl, kakao.maps.ControlPosition.BOTTOMRIGHT);
+    kakaoMap.addControl(zoomControl, kakao.maps.ControlPosition.BOTTOMRIGHT);
 
     this.map = new KakaoMapAdapter(kakaoMap);
     return this.map;

--- a/packages/infrastructures/src/controllers/kakaoMapController.ts
+++ b/packages/infrastructures/src/controllers/kakaoMapController.ts
@@ -1,7 +1,7 @@
 import type { MapController, MapPosition } from '@repo/entity/src/map';
+import type { StoreMapData } from '@repo/entity/src/store';
 
 import { KakaoMapAdapter } from '../adapters/kakaoMapAdapter';
-import type { StoreMapData } from '@repo/entity/src/store';
 
 interface CustomMarker extends kakao.maps.Marker {
   storeData?: {
@@ -13,42 +13,6 @@ interface CustomMarker extends kakao.maps.Marker {
 
 export default class KakaoMapController implements MapController {
   private map: KakaoMapAdapter | null = null;
-
-  getCurrentPosition(): Promise<MapPosition> {
-    return new Promise((resolve, reject) => {
-      if (navigator.geolocation) {
-        navigator.geolocation.getCurrentPosition(
-          (pos) => {
-            if (process.env.NEXT_PUBLIC_USE_API_MOCKING === 'true') {
-              const latitude = 37.498095;
-              const longitude = 127.028979;
-              resolve({ latitude, longitude });
-            } else {
-              const latitude = pos.coords.latitude;
-              const longitude = pos.coords.longitude;
-              resolve({ latitude, longitude });
-            }
-          },
-          (err) => {
-            if (err.code === 3) {
-              reject(new Error('delayed'));
-            }
-            if (err.code === 1) {
-              reject(new Error('blocked'));
-            }
-            reject(err);
-          },
-          {
-            enableHighAccuracy: false,
-            maximumAge: 180000,
-            timeout: 7000,
-          },
-        );
-      } else {
-        reject(new Error('notSupport'));
-      }
-    });
-  }
 
   async createMap(container: HTMLDivElement, position: MapPosition) {
     const level = 3;
@@ -64,92 +28,62 @@ export default class KakaoMapController implements MapController {
     return this.map;
   }
 
-  private createCustomMarker(position: MapPosition, src: string) {
-    const markerOptions = {
-      size: {
-        width: 30,
-        height: 30,
-      },
-      offset: {
-        x: 0,
-        y: 0,
-      },
-    };
-
-    const imageSize = new kakao.maps.Size(
-      markerOptions.size.width,
-      markerOptions.size.height,
-    );
-    const imageOffset = {
-      offset: new kakao.maps.Point(
-        markerOptions.offset.x,
-        markerOptions.offset.y,
-      ),
-    };
-
-    const markerImage = new kakao.maps.MarkerImage(src, imageSize, imageOffset);
-
-    const markerPosition = new kakao.maps.LatLng(
-      position.latitude,
-      position.longitude,
-    );
-
-    const marker = new kakao.maps.Marker({
-      position: markerPosition,
-      image: markerImage,
-    }) as CustomMarker;
-
-    return marker;
-  }
-
   createMarkersWithClusterer(
     storeMapData: StoreMapData[],
     markerImageSrc: string,
     handleMarkerClick: (storeId: number) => void,
-  ) {
+  ): void {
     if (!this.map) {
       throw new Error('Map is not initialized');
     }
-    const kakaoMap = this.map.getNativeMap();
-    const markers: CustomMarker[] = [];
 
-    storeMapData.forEach(({ id, name, address, latitude, longitude }) => {
-      const markerPosition = {
-        latitude: latitude,
-        longitude: longitude,
-      };
-
-      const marker = this.createCustomMarker(markerPosition, markerImageSrc);
-
-      marker.storeData = {
-        id,
-        name,
-        address,
-      };
-
-      kakao.maps.event.addListener(marker, 'click', function () {
-        handleMarkerClick(id);
-      });
-
-      markers.push(marker);
-      marker.setMap(kakaoMap);
-    });
-
-    const clusterOptions = {
-      map: kakaoMap, // 마커들을 클러스터로 관리하고 표시할 지도 객체
-      averageCenter: true, // 클러스터에 포함된 마커들의 평균 위치를 클러스터 마커 위치로 설정
-      minLevel: 7, // 클러스터 할 최소 지도 레벨
-    };
-
-    const clusterer = new kakao.maps.MarkerClusterer(clusterOptions);
-
-    // 클러스터러에 마커들을 추가
-    clusterer.addMarkers(markers);
+    this.map.createMarkersWithClusterer(
+      storeMapData,
+      markerImageSrc,
+      handleMarkerClick,
+    );
   }
 
-  destroyMap() {
-    if (this.map) {
-      this.map = null;
+  clearAllMarkers(): void {
+    if (!this.map) {
+      throw new Error('Map is not initialized');
     }
+
+    this.map.clearAllMarkers();
+  }
+
+  getMarkerById(storeId: number): CustomMarker | undefined {
+    if (!this.map) {
+      throw new Error('Map is not initialized');
+    }
+
+    return this.map.getMarkerById(storeId);
+  }
+
+  createCurrentPosMarker(position: MapPosition, markerImageSrc: string): void {
+    if (!this.map) {
+      throw new Error('Map is not initialized');
+    }
+
+    this.map.createCurrentPosMarker(position, markerImageSrc);
+  }
+
+  updateCurrentPositionMarker(
+    position: MapPosition,
+    markerImageSrc: string,
+  ): void {
+    if (!this.map) {
+      throw new Error('Map is not initialized');
+    }
+
+    this.map.updateCurrentPositionMarker(position, markerImageSrc);
+  }
+
+  removeCurrentPosMarker(): void {
+    if (!this.map) {
+      throw new Error('Map is not initialized');
+    }
+
+    this.map.removeCurrentPositionMarker();
   }
 }

--- a/packages/infrastructures/src/filters/locationFilter.ts
+++ b/packages/infrastructures/src/filters/locationFilter.ts
@@ -1,0 +1,37 @@
+import type { MapPosition } from '@repo/entity/src/map';
+
+export interface LocationFilter {
+  filter(position: MapPosition, accuracy: number): MapPosition;
+}
+
+export class KalmanLocationFilter implements LocationFilter {
+  private lastPosition: MapPosition | null = null;
+  private lastAccuracy: number | null = null;
+
+  filter(newPosition: MapPosition, accuracy: number): MapPosition {
+    if (!this.lastPosition || !this.lastAccuracy) {
+      this.lastPosition = newPosition;
+      this.lastAccuracy = accuracy;
+      return newPosition;
+    }
+
+    // 칼만 게인 계산 (0~1 사이 값)
+    const k = this.lastAccuracy / (this.lastAccuracy + accuracy);
+
+    // 위치 보정
+    const filteredPosition = {
+      latitude:
+        this.lastPosition.latitude +
+        k * (newPosition.latitude - this.lastPosition.latitude),
+      longitude:
+        this.lastPosition.longitude +
+        k * (newPosition.longitude - this.lastPosition.longitude),
+    };
+
+    // 새로운 정확도 계산
+    this.lastAccuracy = (1 - k) * this.lastAccuracy;
+    this.lastPosition = filteredPosition;
+
+    return filteredPosition;
+  }
+}

--- a/packages/infrastructures/src/filters/movingAverageFilter.ts
+++ b/packages/infrastructures/src/filters/movingAverageFilter.ts
@@ -1,0 +1,25 @@
+import type { MapPosition } from '@repo/entity/src/map';
+import type { LocationFilter } from './locationFilter';
+
+export class MovingAverageFilter implements LocationFilter {
+  private positions: MapPosition[] = [];
+
+  constructor(private readonly windowSize: number = 5) {}
+
+  filter(position: MapPosition): MapPosition {
+    this.positions.push(position);
+
+    if (this.positions.length > this.windowSize) {
+      this.positions.shift();
+    }
+
+    return {
+      latitude:
+        this.positions.reduce((sum, pos) => sum + pos.latitude, 0) /
+        this.positions.length,
+      longitude:
+        this.positions.reduce((sum, pos) => sum + pos.longitude, 0) /
+        this.positions.length,
+    };
+  }
+}

--- a/packages/usecase/src/geolocationService.ts
+++ b/packages/usecase/src/geolocationService.ts
@@ -61,12 +61,15 @@ export default class GeolocationService {
     }
   }
 
-  getWatchingPostion(options?: PositionOptions): Promise<MapPosition> {
+  startWatchingPosition(
+    onSuccess: (position: MapPosition) => void,
+    options?: PositionOptions,
+  ) {
     if (!this.geolocationController) {
       throw new Error('geolocationController is not set');
     }
 
-    return this.geolocationController.startWatching(options);
+    this.geolocationController.startWatching(onSuccess, options);
   }
 
   stopWatchingPosition() {

--- a/packages/usecase/src/geolocationService.ts
+++ b/packages/usecase/src/geolocationService.ts
@@ -61,7 +61,7 @@ export default class GeolocationService {
     }
   }
 
-  startWatchingPosition(
+  async startWatchingPosition(
     onSuccess: (position: MapPosition) => void,
     options?: PositionOptions,
   ) {
@@ -69,14 +69,14 @@ export default class GeolocationService {
       throw new Error('geolocationController is not set');
     }
 
-    this.geolocationController.startWatching(onSuccess, options);
+    return await this.geolocationController.startWatching(onSuccess, options);
   }
 
-  stopWatchingPosition() {
+  async stopWatchingPosition() {
     if (!this.geolocationController) {
       throw new Error('geolocationController is not set');
     }
 
-    this.geolocationController.stopWatching();
+    return await this.geolocationController.stopWatching();
   }
 }

--- a/packages/usecase/src/geolocationService.ts
+++ b/packages/usecase/src/geolocationService.ts
@@ -1,0 +1,79 @@
+import type { MapPosition } from '@repo/entity/src/map';
+import type { GeolocationController } from '@repo/entity/src/geolocation';
+
+interface GeolocationErrorMessage {
+  errorMessage: string;
+}
+
+export default class GeolocationService {
+  private readonly geolocationController: GeolocationController | null;
+
+  constructor({
+    geolocationController,
+  }: {
+    geolocationController?: GeolocationController;
+  }) {
+    this.geolocationController = geolocationController ?? null;
+  }
+  async getInitialPosition(): Promise<MapPosition | GeolocationErrorMessage> {
+    if (!this.geolocationController) {
+      throw new Error('geolocationController is not set');
+    }
+
+    try {
+      const permissionStatus = await navigator.permissions.query({
+        name: 'geolocation',
+      });
+
+      let position;
+      switch (permissionStatus.state) {
+        case 'denied':
+          return {
+            errorMessage: '위치 권한 허용 후 서비스 이용이 가능합니다.',
+          };
+        case 'prompt':
+          position = await this.geolocationController.getCurrentPosition();
+          return position;
+        case 'granted':
+          position = await this.geolocationController.getCurrentPosition();
+          return position;
+      }
+    } catch (error) {
+      if (error instanceof Error) {
+        switch (error.message) {
+          case 'delayed':
+            return {
+              errorMessage: '위치 정보를 가져오는데 시간이 너무 오래 걸립니다.',
+            };
+          case 'blocked':
+            return {
+              errorMessage: '위치 정보 접근 권한이 없습니다.',
+            };
+          case 'notSupport':
+            return {
+              errorMessage: '이 브라우저는 위치 정보 기능을 지원하지 않습니다.',
+            };
+          default:
+            return { errorMessage: error.message };
+        }
+      }
+      return { errorMessage: String(error) };
+    }
+  }
+
+  getWatchingPostion(options?: PositionOptions): Promise<MapPosition> {
+    if (!this.geolocationController) {
+      throw new Error('geolocationController is not set');
+    }
+
+    return this.geolocationController.startWatching(options);
+  }
+
+  stopWatchingPosition() {
+    if (!this.geolocationController) {
+      throw new Error('geolocationController is not set');
+    }
+
+    this.geolocationController.stopWatching();
+  }
+}

--- a/packages/usecase/src/geolocationService.ts
+++ b/packages/usecase/src/geolocationService.ts
@@ -15,7 +15,7 @@ export default class GeolocationService {
   }) {
     this.geolocationController = geolocationController ?? null;
   }
-  async getInitialPosition(): Promise<MapPosition | GeolocationErrorMessage> {
+  async getCurrentPosition(): Promise<MapPosition | GeolocationErrorMessage> {
     if (!this.geolocationController) {
       throw new Error('geolocationController is not set');
     }

--- a/packages/usecase/src/mapService.ts
+++ b/packages/usecase/src/mapService.ts
@@ -12,7 +12,7 @@ export default class MapService {
     if (!this.mapController) {
       throw new Error('mapController is not set');
     }
-    this.mapController.createCurrentPosMarker(position, markerImageSrc);
+    this.mapController.createCurrentPositionMarker(position, markerImageSrc);
   }
 
   async initializeMap(container: HTMLDivElement, currentPosition: MapPosition) {
@@ -47,6 +47,20 @@ export default class MapService {
     if (!this.mapController) {
       throw new Error('mapController is not set');
     }
-    this.mapController.updateCurrentPositionMarker(position, markerImageSrc);
+    this.mapController.createCurrentPositionMarker(position, markerImageSrc);
+  }
+
+  async removeCurrentPositionMarker() {
+    if (!this.mapController) {
+      throw new Error('mapController is not set');
+    }
+    this.mapController.removeCurrentPositionMarker();
+  }
+
+  async setMapCenter(position: MapPosition) {
+    if (!this.mapController) {
+      throw new Error('mapController is not set');
+    }
+    this.mapController.setMapCenter(position);
   }
 }

--- a/packages/usecase/src/mapService.ts
+++ b/packages/usecase/src/mapService.ts
@@ -1,127 +1,11 @@
-import type {
-  GeolocationController,
-  MapController,
-  MapPosition,
-} from '@repo/entity/src/map';
+import type { MapController, MapPosition } from '@repo/entity/src/map';
 import type { StoreMapData } from '@repo/entity/src/store';
-
-interface MapErrorMessage {
-  errorMessage: string;
-}
 
 export default class MapService {
   private readonly mapController: MapController | null;
-  private readonly geolocationController: GeolocationController | null;
 
-  constructor({
-    mapController,
-    geolocationController,
-  }: {
-    mapController?: MapController;
-    geolocationController?: GeolocationController;
-  }) {
+  constructor({ mapController }: { mapController?: MapController }) {
     this.mapController = mapController ?? null;
-    this.geolocationController = geolocationController ?? null;
-  }
-  async getInitialPosition(): Promise<MapPosition | MapErrorMessage> {
-    if (!this.mapController) {
-      throw new Error('mapController is not set');
-    }
-
-    if (!this.geolocationController) {
-      throw new Error('geolocationController is not set');
-    }
-
-    try {
-      const permissionStatus = await navigator.permissions.query({
-        name: 'geolocation',
-      });
-
-      let position;
-      switch (permissionStatus.state) {
-        case 'denied':
-          return {
-            errorMessage: '위치 권한 허용 후 서비스 이용이 가능합니다.',
-          };
-        case 'prompt':
-          position = await this.geolocationController.getInitialPosition();
-          return position;
-        case 'granted':
-          position = await this.geolocationController.getInitialPosition();
-          return position;
-      }
-    } catch (error) {
-      if (error instanceof Error) {
-        switch (error.message) {
-          case 'delayed':
-            return {
-              errorMessage: '위치 정보를 가져오는데 시간이 너무 오래 걸립니다.',
-            };
-          case 'blocked':
-            return {
-              errorMessage: '위치 정보 접근 권한이 없습니다.',
-            };
-          case 'notSupport':
-            return {
-              errorMessage: '이 브라우저는 위치 정보 기능을 지원하지 않습니다.',
-            };
-          default:
-            return { errorMessage: error.message };
-        }
-      }
-      return { errorMessage: String(error) };
-    }
-  }
-
-  async getcurrentPosition(): Promise<MapPosition | MapErrorMessage> {
-    if (!this.mapController) {
-      throw new Error('mapController is not set');
-    }
-
-    if (!this.geolocationController) {
-      throw new Error('geolocationController is not set');
-    }
-
-    try {
-      const permissionStatus = await navigator.permissions.query({
-        name: 'geolocation',
-      });
-
-      let position;
-      switch (permissionStatus.state) {
-        case 'denied':
-          return {
-            errorMessage: '위치 권한 허용 후 서비스 이용이 가능합니다.',
-          };
-        case 'prompt':
-          position = await this.geolocationController.getCurrentPosition();
-          return position;
-        case 'granted':
-          position = await this.geolocationController.getCurrentPosition();
-          return position;
-      }
-    } catch (error) {
-      if (error instanceof Error) {
-        switch (error.message) {
-          case 'delayed':
-            return {
-              errorMessage: '위치 정보를 가져오는데 시간이 너무 오래 걸립니다.',
-            };
-          case 'blocked':
-            return {
-              errorMessage: '위치 정보 접근 권한이 없습니다.',
-            };
-          case 'notSupport':
-            return {
-              errorMessage: '이 브라우저는 위치 정보 기능을 지원하지 않습니다.',
-            };
-          default:
-            return { errorMessage: error.message };
-        }
-      }
-
-      return { errorMessage: String(error) };
-    }
   }
 
   async addCurrentPositionMaker(position: MapPosition, markerImageSrc: string) {
@@ -129,14 +13,6 @@ export default class MapService {
       throw new Error('mapController is not set');
     }
     this.mapController.createCurrentPosMarker(position, markerImageSrc);
-  }
-
-  stopWatchingPosition() {
-    if (!this.geolocationController) {
-      throw new Error('geolocationController is not set');
-    }
-
-    this.geolocationController.stopWatching();
   }
 
   async initializeMap(container: HTMLDivElement, currentPosition: MapPosition) {

--- a/packages/usecase/src/mapService.ts
+++ b/packages/usecase/src/mapService.ts
@@ -1,4 +1,8 @@
-import type { MapController, MapPosition } from '@repo/entity/src/map';
+import type {
+  GeolocationController,
+  MapController,
+  MapPosition,
+} from '@repo/entity/src/map';
 import type { StoreMapData } from '@repo/entity/src/store';
 
 interface MapErrorMessage {
@@ -7,13 +11,25 @@ interface MapErrorMessage {
 
 export default class MapService {
   private readonly mapController: MapController | null;
+  private readonly geolocationController: GeolocationController | null;
 
-  constructor({ mapController }: { mapController?: MapController }) {
+  constructor({
+    mapController,
+    geolocationController,
+  }: {
+    mapController?: MapController;
+    geolocationController?: GeolocationController;
+  }) {
     this.mapController = mapController ?? null;
+    this.geolocationController = geolocationController ?? null;
   }
-  async getCurrentPosition(): Promise<MapPosition | MapErrorMessage> {
+  async getInitialPosition(): Promise<MapPosition | MapErrorMessage> {
     if (!this.mapController) {
       throw new Error('mapController is not set');
+    }
+
+    if (!this.geolocationController) {
+      throw new Error('geolocationController is not set');
     }
 
     try {
@@ -28,10 +44,10 @@ export default class MapService {
             errorMessage: '위치 권한 허용 후 서비스 이용이 가능합니다.',
           };
         case 'prompt':
-          position = await this.mapController.getCurrentPosition();
+          position = await this.geolocationController.getInitialPosition();
           return position;
         case 'granted':
-          position = await this.mapController.getCurrentPosition();
+          position = await this.geolocationController.getInitialPosition();
           return position;
       }
     } catch (error) {
@@ -55,6 +71,72 @@ export default class MapService {
       }
       return { errorMessage: String(error) };
     }
+  }
+
+  async getcurrentPosition(): Promise<MapPosition | MapErrorMessage> {
+    if (!this.mapController) {
+      throw new Error('mapController is not set');
+    }
+
+    if (!this.geolocationController) {
+      throw new Error('geolocationController is not set');
+    }
+
+    try {
+      const permissionStatus = await navigator.permissions.query({
+        name: 'geolocation',
+      });
+
+      let position;
+      switch (permissionStatus.state) {
+        case 'denied':
+          return {
+            errorMessage: '위치 권한 허용 후 서비스 이용이 가능합니다.',
+          };
+        case 'prompt':
+          position = await this.geolocationController.getCurrentPosition();
+          return position;
+        case 'granted':
+          position = await this.geolocationController.getCurrentPosition();
+          return position;
+      }
+    } catch (error) {
+      if (error instanceof Error) {
+        switch (error.message) {
+          case 'delayed':
+            return {
+              errorMessage: '위치 정보를 가져오는데 시간이 너무 오래 걸립니다.',
+            };
+          case 'blocked':
+            return {
+              errorMessage: '위치 정보 접근 권한이 없습니다.',
+            };
+          case 'notSupport':
+            return {
+              errorMessage: '이 브라우저는 위치 정보 기능을 지원하지 않습니다.',
+            };
+          default:
+            return { errorMessage: error.message };
+        }
+      }
+
+      return { errorMessage: String(error) };
+    }
+  }
+
+  async addCurrentPositionMaker(position: MapPosition, markerImageSrc: string) {
+    if (!this.mapController) {
+      throw new Error('mapController is not set');
+    }
+    this.mapController.createCurrentPosMarker(position, markerImageSrc);
+  }
+
+  stopWatchingPosition() {
+    if (!this.geolocationController) {
+      throw new Error('geolocationController is not set');
+    }
+
+    this.geolocationController.stopWatching();
   }
 
   async initializeMap(container: HTMLDivElement, currentPosition: MapPosition) {
@@ -82,11 +164,13 @@ export default class MapService {
     );
   }
 
-  destroyMap() {
+  async updateCurrentPositionMarker(
+    position: MapPosition,
+    markerImageSrc: string,
+  ) {
     if (!this.mapController) {
       throw new Error('mapController is not set');
     }
-
-    this.mapController.destroyMap();
+    this.mapController.updateCurrentPositionMarker(position, markerImageSrc);
   }
 }


### PR DESCRIPTION
### Summary
- geolocation 메서드가 늘어남에 따라 geolocation controller로 분리
- 실시간 마커가 업데이트 되기 위해선 지도에 올라온 마커 실시간으로 지워주어야함 - 마커 관리 필요 -> KakaoMapAdapter에 마커 관리 위임
- 실시간 위치 테스트 중, 마커의 위치가 현재 위치와 거의 1.5km나 차이남 발견
  - 카카오 공식에서는 
     - geolocation이 웹 환경에서 부족한 점이 있어서 별도의 IP 타겟팅을 사용한다고 답변
     - 또는 알고리즘을 개발해서 사용해야한다고 답변
  - 클로드에게 관련 알고리즘 필터 작성 부탁해서 적용
    - locationFilter, movingAverageFilter
    - infrastructure/filters 폴더 만들어서 관리
 - service에선 geolocation controller, map controller 같이 사용


### Remarks
- Adapter에 map 객체까지 위임 시켜야할 것 같은데 고민중
- service에선 geolocation controller, map controller 같이 사용  --> service도 분리해야할까요?
- 실시간 위치 뿐만 아니라 처음 위치 가져오는 메서드에도 filter 적용해야함(현재 실시간 위치만 적용되어있음)
- filter 모바일 환경에서도 제대로 적용되는지 테스트 필요(단말기 gps 사용이라 geolocation이 다르게 반환될 수 있음 - 더 정확하므로 필터가 오히려 값을 이상하게 바꿀 수도 있음)
- 현재 실시간 위치 업데이트는 되지 않는 중이라 추가 필요
- 지도의 실시간 위치 버튼 누르면 지도 중심 이동하도록 수정 예정
 