### PR TITLE
[user preference] fix: 프론트에서 userPreferenceId -> userPreferenceName 사용하도록 수정

### DIFF
--- a/apps/desserbee-web/src/app/[lang]/(user)/(menu)/(search)/_hooks/useTag.ts
+++ b/apps/desserbee-web/src/app/[lang]/(user)/(menu)/(search)/_hooks/useTag.ts
@@ -1,25 +1,26 @@
+import type { Preference } from '@repo/entity/src/preference';
 import { useState } from 'react';
 
 export const useTag = () => {
-  const [selectedCategories, setSelectedCategories] = useState<Set<number>>(
+  const [selectedCategories, setSelectedCategories] = useState<Set<Preference>>(
     new Set(),
   );
   const [isMyPreferSelected, setIsMyPreferSelected] = useState(false);
 
-  const updateSelectedTag = (category: number) => {
+  const updateSelectedTag = (categoryName: Preference) => {
     setSelectedCategories((prev) => {
       const newSet = new Set(prev);
-      if (newSet.has(category)) {
-        newSet.delete(category);
+      if (newSet.has(categoryName)) {
+        newSet.delete(categoryName);
       } else {
-        newSet.add(category);
+        newSet.add(categoryName);
       }
       return newSet;
     });
     setIsMyPreferSelected(false);
   };
 
-  const handleMyPreferenceTagClick = (userPreferences: number[]) => {
+  const handleMyPreferenceTagClick = (userPreferences: Preference[]) => {
     setIsMyPreferSelected((prev) => {
       const newValue = !prev;
 

--- a/apps/desserbee-web/src/app/[lang]/(user)/(menu)/(search)/map/_components/KakaoMap/action.tsx
+++ b/apps/desserbee-web/src/app/[lang]/(user)/(menu)/(search)/map/_components/KakaoMap/action.tsx
@@ -1,5 +1,6 @@
 'use server';
 
+import type { Preference } from '@repo/entity/src/preference';
 import AuthNextAppRouteRepository from '@repo/infrastructures/src/repositories/authNextAppRouteRepository';
 import StoreAPIRepository from '@repo/infrastructures/src/repositories/storeAPIRepository';
 import StoreService from '@repo/usecase/src/storeService';
@@ -10,13 +11,13 @@ export async function getNearbyStores({
   latitude,
   longitude,
   radius,
-  preferenceTagIds,
+  preferenceTagNames,
   searchKeyword,
 }: {
   latitude: number;
   longitude: number;
   radius: number;
-  preferenceTagIds?: number[];
+  preferenceTagNames?: Preference[];
   searchKeyword?: string;
 }) {
   const storeService = new StoreService({
@@ -28,7 +29,7 @@ export async function getNearbyStores({
     latitude: latitude,
     longitude: longitude,
     radius: radius,
-    preferenceTagIds,
+    preferenceTagNames,
     searchKeyword,
   });
 

--- a/apps/desserbee-web/src/app/[lang]/(user)/(menu)/(search)/map/_components/KakaoMap/index.tsx
+++ b/apps/desserbee-web/src/app/[lang]/(user)/(menu)/(search)/map/_components/KakaoMap/index.tsx
@@ -45,6 +45,7 @@ import { ReFetchStoreBtn } from '../ReFetchStoreBtn';
 import { calculateDistance } from '../../_utils/distance';
 import { useTag } from '../../../_hooks/useTag';
 import { getNearbyStores } from './action';
+import type { Preference } from '@repo/entity/src/preference';
 
 interface KakaoMapProps {
   preferenceCategories: PreferenceData[];
@@ -94,7 +95,6 @@ export function KakaoMap({ preferenceCategories }: KakaoMapProps) {
     longitude: 0,
   });
 
-  const [searchKeyword, setSearchKeyword] = useState<string>('');
   const [nearByStores, setNearByStores] = useState<NearByStoreData[]>([]);
 
   const [, setRetryCount] = useState(0);
@@ -125,7 +125,7 @@ export function KakaoMap({ preferenceCategories }: KakaoMapProps) {
     });
   }, [closeModal, push]);
 
-  //  서비스 초기화
+  // 제일 먼저 서비스 초기화
   const initializeServices = () => {
     const mapService = new MapService({
       mapController: new KakaoMapController(),
@@ -145,7 +145,7 @@ export function KakaoMap({ preferenceCategories }: KakaoMapProps) {
     return { mapService, geoService, storeService };
   };
 
-  // 화면 내 거리 계산 (처음 500km, 이후 최소 4km 최대 화면 크기만큼의 거리)
+  // 화면 내 거리 계산
   const calculateFetchRadius = useCallback(() => {
     if (!servicesRef.current.mapService) {
       return 4000;
@@ -185,11 +185,11 @@ export function KakaoMap({ preferenceCategories }: KakaoMapProps) {
     return Math.max(screenDistance, minNeighborhoodRadius) * 1000;
   }, [sessionStorageRepository]);
 
-  // 가게 불러오기 메서드 (실질적인 service 사용)
+  // 가게
   const fetchNearbyStores = useCallback(
     async (
       position: MapPosition,
-      preferenceTagIds?: number[],
+      preferenceTagNames?: Preference[],
       searchKeyword?: string,
     ) => {
       try {
@@ -203,7 +203,7 @@ export function KakaoMap({ preferenceCategories }: KakaoMapProps) {
           latitude: position.latitude,
           longitude: position.longitude,
           radius: fetchRadius,
-          preferenceTagIds,
+          preferenceTagNames,
           searchKeyword,
         });
 
@@ -218,7 +218,8 @@ export function KakaoMap({ preferenceCategories }: KakaoMapProps) {
           setRetryCount((prev) => prev + 1);
           retryCountRef.current += 1;
           setTimeout(
-            () => fetchNearbyStores(position, preferenceTagIds, searchKeyword),
+            () =>
+              fetchNearbyStores(position, preferenceTagNames, searchKeyword),
             RETRY_DELAY,
           );
           return;
@@ -235,6 +236,13 @@ export function KakaoMap({ preferenceCategories }: KakaoMapProps) {
     },
     [calculateFetchRadius],
   );
+
+  const handleMapCenterChange = useCallback(() => {
+    if (servicesRef.current.mapService) {
+      const center = servicesRef.current.mapService.getMapCenter();
+      setMapCenter(center);
+    }
+  }, []);
 
   // 각 마커 클릭 - 바텀시트 열리고, 클릭한 마커 storeId 업데이트
   const handleStoreMarkerClick = useCallback(
@@ -382,39 +390,6 @@ export function KakaoMap({ preferenceCategories }: KakaoMapProps) {
     return result;
   };
 
-  // 지도 중심으로 이동
-  const handleMapCenterChange = useCallback(() => {
-    if (servicesRef.current.mapService) {
-      const center = servicesRef.current.mapService.getMapCenter();
-      setMapCenter(center);
-    }
-  }, []);
-
-  // 현재 유저 위치로 이동
-  const handleMoveToCurrentPosition = useCallback(() => {
-    if (servicesRef.current.mapService && isMapLoaded) {
-      servicesRef.current.mapService.setMapCenter(currentPosition);
-    }
-  }, [isMapLoaded, currentPosition]);
-
-  const mapCenterRef = useRef(mapCenter);
-
-  useEffect(() => {
-    mapCenterRef.current = mapCenter;
-  }, [mapCenter]);
-
-  // 버튼 누르면 현재 위치로 이동하도록
-  const mapPanelProps = useMemo(
-    () => ({
-      moveToCurrentPosition: handleMoveToCurrentPosition,
-    }),
-    [handleMoveToCurrentPosition],
-  );
-
-  const handleRefetchBtnClick = () => {
-    setIsFetchRequired(true);
-  };
-
   // 지도 첫 초기화
   const loadMap = useCallback(
     async (
@@ -437,7 +412,6 @@ export function KakaoMap({ preferenceCategories }: KakaoMapProps) {
           openPermissionModal,
         );
 
-        // 지도 초기화 위치 결정 (저장된 위치 우선)
         const mapCenterPosition = lastPosition || actualPosition;
 
         // 위치 정보가 없는 경우 초기화 불가능
@@ -458,8 +432,11 @@ export function KakaoMap({ preferenceCategories }: KakaoMapProps) {
           handleMapCenterChange,
         );
 
-        // 지도 중심 설정 (이미 initializeMap에서 설정했으므로 중복 호출 제거)
-        setMapCenter(mapCenterPosition);
+        // lastPosition이 있을 경우 지도 중심 설정
+        if (lastPosition) {
+          setMapCenter(lastPosition);
+          await initializedServices.mapService.setMapCenter(lastPosition);
+        }
 
         // 실제 위치 정보가 있는 경우에만 현재 위치 마커 추가
         if (actualPosition) {
@@ -470,6 +447,12 @@ export function KakaoMap({ preferenceCategories }: KakaoMapProps) {
               userMarkerImage.src,
             );
           currentPositionMarkerRef.current = marker;
+
+          // 저장된 위치가 없는 경우에만 실제 위치로 지도 중심 이동
+          if (!lastPosition) {
+            await initializedServices.mapService.setMapCenter(actualPosition);
+            setMapCenter(actualPosition);
+          }
         }
 
         // 위치 추적 시작
@@ -505,6 +488,126 @@ export function KakaoMap({ preferenceCategories }: KakaoMapProps) {
       updateCurrentMarker,
     ],
   );
+
+  // 현재 유저 위치로 이동
+  const handleMoveToCurrentPosition = useCallback(() => {
+    if (servicesRef.current.mapService && isMapLoaded) {
+      servicesRef.current.mapService.setMapCenter(currentPosition);
+    }
+  }, [isMapLoaded, currentPosition]);
+
+  const mapCenterRef = useRef(mapCenter);
+
+  useEffect(() => {
+    mapCenterRef.current = mapCenter;
+  }, [mapCenter]);
+
+  // 검색어 상태 추가
+  const [searchKeyword, setSearchKeyword] = useState<string>('');
+
+  // URL 해시 변경 감지
+  useEffect(() => {
+    // 초기 해시 확인
+    const checkInitialHash = () => {
+      if (typeof window !== 'undefined') {
+        const hash = window.location.hash;
+        if (hash.startsWith('#q=')) {
+          const query = hash.substring(3);
+          setSearchKeyword(query);
+          console.log('Initial hash detected, setting bottom sheet:', !!query);
+        } else {
+          setSearchKeyword('');
+        }
+      }
+    };
+
+    // 해시 변경 이벤트 핸들러
+    const handleHashChange = () => {
+      const hash = window.location.hash;
+      if (hash.startsWith('#q=')) {
+        const query = hash.substring(3);
+        setSearchKeyword(query);
+      } else {
+        setSearchKeyword('');
+      }
+    };
+
+    // 초기 해시 확인
+    checkInitialHash();
+
+    // 해시 변경 이벤트 리스너 등록
+    window.addEventListener('hashchange', handleHashChange);
+
+    // 컴포넌트 언마운트 시 이벤트 리스너 제거
+    return () => {
+      window.removeEventListener('hashchange', handleHashChange);
+    };
+  }, []);
+
+  // 지도 중심만 받아와서 가게 fetch
+  useEffect(() => {
+    if (isFetchRequired) {
+      const fetchAndUpdate = async () => {
+        const stores = await fetchNearbyStores(mapCenterRef.current);
+        if (stores) {
+          await updateNewClusterMarkers(stores);
+          setIsFetchRequired(false);
+        }
+      };
+      fetchAndUpdate();
+    }
+  }, [isFetchRequired, fetchNearbyStores, updateNewClusterMarkers]);
+
+  // 태그, 검색 포함 필터링 적용된 가게 fetch
+  const previousSelectedTagsRef = useRef<Preference[]>([]);
+  const previousSearchKeywordRef = useRef<string>('');
+
+  useEffect(() => {
+    if (
+      JSON.stringify(previousSelectedTagsRef.current) !==
+        JSON.stringify(selectedPreferenceTags) ||
+      previousSearchKeywordRef.current !== searchKeyword
+    ) {
+      const fetchAndUpdate = async () => {
+        const stores = await fetchNearbyStores(
+          mapCenterRef.current,
+          selectedPreferenceTags,
+          searchKeyword,
+        );
+
+        if (stores) {
+          await updateNewClusterMarkers(stores);
+          setIsFetchRequired(false);
+
+          // 약간의 지연을 두어 상태 업데이트가 확실히 반영되도록 함
+          setTimeout(() => {
+            setNearByStores(stores);
+          }, 100);
+        }
+      };
+      fetchAndUpdate();
+      previousSelectedTagsRef.current = selectedPreferenceTags;
+      previousSearchKeywordRef.current = searchKeyword;
+    }
+  }, [
+    selectedPreferenceTags,
+    searchKeyword,
+    fetchNearbyStores,
+    updateNewClusterMarkers,
+  ]);
+
+  // 에러 메시지
+  useEffect(() => {
+    if (error) {
+      const timer = setTimeout(() => {
+        setError(null);
+      }, 3000);
+
+      return () => {
+        clearTimeout(timer);
+      };
+    }
+  }, [error]);
 
   // 카카오맵 초기화 로직
   useEffect(() => {
@@ -545,174 +648,6 @@ export function KakaoMap({ preferenceCategories }: KakaoMapProps) {
     }
   }, [isScriptLoaded, isInitialized, loadMap, sessionStorageRepository]);
 
-  // 아무 필터링 없이 가게 불러오기
-  useEffect(() => {
-    if (isFetchRequired) {
-      const fetchAndUpdate = async () => {
-        const stores = await fetchNearbyStores(mapCenterRef.current);
-        if (stores) {
-          await updateNewClusterMarkers(stores);
-          setIsFetchRequired(false);
-        }
-      };
-      fetchAndUpdate();
-    }
-  }, [isFetchRequired, fetchNearbyStores, updateNewClusterMarkers]);
-
-  // 현재 지도 중심, 태그, 검색 포함 필터링 적용된 가게 불러오기
-  const previousSelectedTagsRef = useRef<number[]>([]);
-  const previousSearchKeywordRef = useRef<string>('');
-
-  useEffect(() => {
-    if (
-      JSON.stringify(previousSelectedTagsRef.current) !==
-        JSON.stringify(selectedPreferenceTags) ||
-      previousSearchKeywordRef.current !== searchKeyword
-    ) {
-      const fetchAndUpdate = async () => {
-        const stores = await fetchNearbyStores(
-          mapCenterRef.current,
-          selectedPreferenceTags,
-          searchKeyword,
-        );
-
-        if (stores) {
-          await updateNewClusterMarkers(stores);
-          setIsFetchRequired(false);
-
-          // 약간의 지연을 두어 상태 업데이트가 확실히 반영되도록 함
-          setTimeout(() => {
-            setNearByStores(stores);
-          }, 100);
-        }
-      };
-      fetchAndUpdate();
-      previousSelectedTagsRef.current = selectedPreferenceTags;
-      previousSearchKeywordRef.current = searchKeyword;
-    }
-  }, [
-    selectedPreferenceTags,
-    searchKeyword,
-    fetchNearbyStores,
-    updateNewClusterMarkers,
-  ]);
-
-  // URL 해시 변경 감지 (검색)
-  useEffect(() => {
-    // 초기 해시 확인
-    const checkInitialHash = () => {
-      if (typeof window !== 'undefined') {
-        const hash = window.location.hash;
-        if (hash.startsWith('#q=')) {
-          const query = hash.substring(3);
-          setSearchKeyword(query);
-          console.log('Initial hash detected, setting bottom sheet:', !!query);
-        } else {
-          setSearchKeyword('');
-        }
-      }
-    };
-
-    // 해시 변경 이벤트 핸들러
-    const handleHashChange = () => {
-      const hash = window.location.hash;
-      if (hash.startsWith('#q=')) {
-        const query = hash.substring(3);
-        setSearchKeyword(query);
-      } else {
-        setSearchKeyword('');
-      }
-    };
-
-    // 초기 해시 확인
-    checkInitialHash();
-
-    // 해시 변경 이벤트 리스너 등록
-    window.addEventListener('hashchange', handleHashChange);
-
-    // 컴포넌트 언마운트 시 이벤트 리스너 제거
-    return () => {
-      window.removeEventListener('hashchange', handleHashChange);
-    };
-  }, []);
-
-  // 디저트 메이트에서 지도로 이동 파라미터 불러왔을 때 (위도, 경도, keyword(가게이름))
-  const moveToStore = useCallback(() => {
-    if (!isMapLoaded || !servicesRef.current.mapService) return;
-
-    const latParam = searchParams.get('latitude');
-    const lngParam = searchParams.get('longitude');
-    const keyword = searchParams.get('keyword');
-
-    if (!latParam || !lngParam || !keyword) return;
-
-    const paramPosition = {
-      latitude: parseFloat(latParam),
-      longitude: parseFloat(lngParam),
-    };
-
-    // 유효한 좌표인지 확인
-    if (!isNaN(paramPosition.latitude) && !isNaN(paramPosition.longitude)) {
-      servicesRef.current.mapService.setMapCenter(paramPosition);
-      servicesRef.current.mapService.setMapLevel(1);
-      setMapCenter(paramPosition);
-      setIsFetchRequired(true);
-
-      fetchNearbyStores(paramPosition, [], keyword)
-        .then((stores) => {
-          if (stores) {
-            updateNewClusterMarkers(stores);
-          }
-        })
-        .catch((error) => {
-          console.error('마커 fetch 실패:', error);
-          setError('마커를 불러오는데 실패했습니다.');
-        });
-    }
-  }, [isMapLoaded, searchParams, fetchNearbyStores, updateNewClusterMarkers]);
-
-  useEffect(() => {
-    if (!isMapLoaded) return;
-
-    const hasLocationParams =
-      searchParams.get('latitude') && searchParams.get('longitude');
-
-    // 이미 지도가 초기화된 상태에서만 위치 이동 처리
-    if (hasLocationParams) {
-      moveToStore();
-    }
-  }, [isMapLoaded, moveToStore, searchParams]);
-
-  const preferenceTagsProps = useMemo(
-    () => ({
-      categories: preferenceCategories,
-      isMyPreferSelected,
-      handleMyPreferenceTagClick,
-      updateSelectedTag,
-      selectedCategories,
-    }),
-    [
-      preferenceCategories,
-      handleMyPreferenceTagClick,
-      isMyPreferSelected,
-      updateSelectedTag,
-      selectedCategories,
-    ],
-  );
-
-  // 에러 메시지
-  useEffect(() => {
-    if (error) {
-      const timer = setTimeout(() => {
-        setError(null);
-      }, 3000);
-
-      return () => {
-        clearTimeout(timer);
-      };
-    }
-  }, [error]);
-
   // 컴포넌트 언마운트 시
   useEffect(() => {
     return () => {
@@ -744,6 +679,86 @@ export function KakaoMap({ preferenceCategories }: KakaoMapProps) {
       }
     };
   }, [isInitialized]);
+
+  const moveToStore = useCallback(() => {
+    if (!isMapLoaded || !servicesRef.current.mapService) return;
+
+    const latParam = searchParams.get('latitude');
+    const lngParam = searchParams.get('longitude');
+
+    if (!latParam || !lngParam) return;
+
+    const paramPosition = {
+      latitude: parseFloat(latParam),
+      longitude: parseFloat(lngParam),
+    };
+
+    // 유효한 좌표인지 확인
+    if (!isNaN(paramPosition.latitude) && !isNaN(paramPosition.longitude)) {
+      servicesRef.current.mapService.setMapCenter(paramPosition);
+      servicesRef.current.mapService.setMapLevel(1);
+      setMapCenter(paramPosition);
+      setIsFetchRequired(true);
+
+      fetchNearbyStores(paramPosition)
+        .then((stores) => {
+          if (stores) {
+            updateNewClusterMarkers(stores);
+          }
+        })
+        .catch((error) => {
+          console.error('마커 fetch 실패:', error);
+          setError('마커를 불러오는데 실패했습니다.');
+        });
+    }
+  }, [isMapLoaded, searchParams, fetchNearbyStores, updateNewClusterMarkers]);
+
+  useEffect(() => {
+    if (!isMapLoaded) return;
+
+    const hasLocationParams =
+      searchParams.get('latitude') && searchParams.get('longitude');
+    const lastPosition = sessionStorageRepository.get(
+      'lastPosition',
+    ) as MapPosition;
+
+    if (hasLocationParams) {
+      moveToStore();
+    } else if (lastPosition) {
+      servicesRef.current.mapService?.setMapCenter(lastPosition);
+      setMapCenter(lastPosition);
+      setIsFetchRequired(true);
+    }
+  }, [isMapLoaded, moveToStore, searchParams, sessionStorageRepository]);
+
+  const preferenceTagsProps = useMemo(
+    () => ({
+      categories: preferenceCategories,
+      isMyPreferSelected,
+      handleMyPreferenceTagClick,
+      updateSelectedTag,
+      selectedCategories,
+    }),
+    [
+      preferenceCategories,
+      handleMyPreferenceTagClick,
+      isMyPreferSelected,
+      updateSelectedTag,
+      selectedCategories,
+    ],
+  );
+
+  // 버튼에 연동
+  const mapPanelProps = useMemo(
+    () => ({
+      moveToCurrentPosition: handleMoveToCurrentPosition,
+    }),
+    [handleMoveToCurrentPosition],
+  );
+
+  const handleRefetchBtnClick = () => {
+    setIsFetchRequired(true);
+  };
 
   return (
     <div>

--- a/apps/desserbee-web/src/app/[lang]/(user)/(menu)/(search)/map/_components/PreferenceTags/index.tsx
+++ b/apps/desserbee-web/src/app/[lang]/(user)/(menu)/(search)/map/_components/PreferenceTags/index.tsx
@@ -47,7 +47,6 @@ export function PreferenceTags({
   };
 
   const handleTagClick = (categoryName: Preference) => {
-    console.log('Tag Clicked:', categoryName);
     if (user) {
       updateSelectedTag(categoryName);
     } else {

--- a/apps/desserbee-web/src/app/[lang]/(user)/(menu)/(search)/map/_components/PreferenceTags/index.tsx
+++ b/apps/desserbee-web/src/app/[lang]/(user)/(menu)/(search)/map/_components/PreferenceTags/index.tsx
@@ -11,17 +11,14 @@ import { MyPreferNotSignInModal } from '../../_modals/MyPreferNotSignInModal';
 import { PortalContext } from '@repo/ui/contexts/PortalContext';
 import type { PreferenceData } from '@repo/entity/src/store';
 import { UserContext } from '@/contexts/UserContext';
-import PreferenceConverter from '@repo/infrastructures/src/mappers/preferenceConverter';
-
-// FIXME: 리팩토링이 필요한데 지금 할수 없어서 임시 사용 (원래 req, res raw data 변환용)
-const preferenceConverter = new PreferenceConverter();
+import type { Preference } from '@repo/entity/src/preference';
 
 interface PreferenceTagsProps {
   categories: PreferenceData[];
   isMyPreferSelected: boolean;
-  selectedCategories: Set<number>;
-  handleMyPreferenceTagClick: (userPreferences: number[]) => void;
-  updateSelectedTag: (category: number) => void;
+  selectedCategories: Set<Preference>;
+  handleMyPreferenceTagClick: (userPreferences: Preference[]) => void;
+  updateSelectedTag: (categoryName: Preference) => void;
 }
 
 export function PreferenceTags({
@@ -40,9 +37,8 @@ export function PreferenceTags({
   };
 
   const handleMyPreferenceBtnClick = () => {
-    console.log('My Preference Button Clicked');
     if (user) {
-      handleMyPreferenceTagClick(preferenceConverter.convertPreferenceToRaw(user.preferences));
+      handleMyPreferenceTagClick(user.preferences);
     } else {
       push('modal', {
         component: <MyPreferNotSignInModal onClose={closeModal} />,
@@ -50,10 +46,10 @@ export function PreferenceTags({
     }
   };
 
-  const handleTagClick = (categoryId: number) => {
-    console.log('Tag Clicked:', categoryId);
+  const handleTagClick = (categoryName: Preference) => {
+    console.log('Tag Clicked:', categoryName);
     if (user) {
-      updateSelectedTag(categoryId);
+      updateSelectedTag(categoryName);
     } else {
       push('modal', {
         component: <MyPreferNotSignInModal onClose={closeModal} />,
@@ -93,11 +89,11 @@ export function PreferenceTags({
             >
               <div className="px-1 py-1">
                 <Tag
-                  onClick={() => handleTagClick(category.id)}
+                  onClick={() => handleTagClick(category.preferenceName)}
                   className={cn(
                     // 'text-3 md:text-lg font-medium py-[6px] md:py-2 md:px-3',
                     'text-3  font-medium py-[6px]',
-                    selectedCategories.has(category.id) &&
+                    selectedCategories.has(category.preferenceName) &&
                       'bg-primary text-white',
                   )}
                 >

--- a/apps/desserbee-web/src/app/[lang]/(user)/(menu)/(search)/store/[storeId]/@saveStoreSheet/_components/SaveStoreBottomSheetContainer/action.tsx
+++ b/apps/desserbee-web/src/app/[lang]/(user)/(menu)/(search)/store/[storeId]/@saveStoreSheet/_components/SaveStoreBottomSheetContainer/action.tsx
@@ -1,5 +1,6 @@
 'use server';
 
+import type { Preference } from '@repo/entity/src/preference';
 import AuthNextAppRouteRepository from '@repo/infrastructures/src/repositories/authNextAppRouteRepository';
 import StoreAPIRepository from '@repo/infrastructures/src/repositories/storeAPIRepository';
 import StoreService from '@repo/usecase/src/storeService';
@@ -54,7 +55,7 @@ export async function getSavedListAll({ userUuid }: GetSavedListAll) {
 interface AddStoreInSavedList {
   listId: number;
   storeUuid: string;
-  userPreferences: number[];
+  userPreferences: Preference[];
 }
 
 export async function addStoreInSavedList({

--- a/apps/desserbee-web/src/app/[lang]/(user)/(menu)/(search)/store/[storeId]/@saveStoreSheet/_components/SaveStoreBottomSheetContainer/index.tsx
+++ b/apps/desserbee-web/src/app/[lang]/(user)/(menu)/(search)/store/[storeId]/@saveStoreSheet/_components/SaveStoreBottomSheetContainer/index.tsx
@@ -17,10 +17,6 @@ import {
   createSavedList,
   getSavedListAll,
 } from './action';
-import PreferenceConverter from '@repo/infrastructures/src/mappers/preferenceConverter';
-
-// FIXME: 리팩토링이 필요한데 지금 할수 없어서 임시 사용 (원래 req, res raw data 변환용)
-const preferenceConverter = new PreferenceConverter();
 
 interface SaveStoreBottomSheetContainerProps {
   showBottomSheet: boolean;
@@ -118,7 +114,7 @@ export function SaveStoreBottomSheetContainer({
       await addStoreInSavedList({
         listId: listId as number,
         storeUuid,
-        userPreferences: preferenceConverter.convertPreferenceToRaw(user?.preferences || []),
+        userPreferences: user?.preferences || [],
       });
 
       setSuccessMessage('저장이 완료되었습니다');

--- a/packages/entity/src/store.ts
+++ b/packages/entity/src/store.ts
@@ -1,4 +1,5 @@
 import type { BaseRequestData } from './appMetadata';
+import type { Preference } from './preference';
 
 export interface Store {
   storeId: number;
@@ -73,14 +74,12 @@ export interface SavedList {
   savedListId: number | null;
 }
 
-// export type StoreTag = '베이커리' | '루프탑 있음' | '애완동물 동반 가능'; // TODO: 전체 카테고리 정리하기
-
 // store
 export interface NearByStoreRequest {
   latitude: number;
   longitude: number;
   radius: number;
-  preferenceTagIds?: number[];
+  preferenceTagNames?: Preference[];
   searchKeyword?: string;
 }
 
@@ -88,7 +87,7 @@ export interface NearbyFilteredStoresRequest {
   latitude: number;
   longitude: number;
   radius: number;
-  preferenceTagId: number[];
+  preferenceTagNames: Preference[];
 }
 
 export interface NearByStoreSearchRequest {
@@ -497,7 +496,7 @@ export interface GetMenuListRequest {
 
 export interface PreferenceData {
   id: number;
-  preferenceName: string;
+  preferenceName: Preference;
   preferenceDesc: string;
 }
 

--- a/packages/entity/src/store.ts
+++ b/packages/entity/src/store.ts
@@ -434,7 +434,7 @@ export interface EditSavedListResponse {
 export interface AddStoreInSavedListRequest {
   listId: number;
   storeUuid: string;
-  userPreferences: number[];
+  userPreferences: Preference[];
 }
 
 export interface AddStoreInSavedListResponse {
@@ -445,7 +445,7 @@ export interface AddStoreInSavedListResponse {
   storeName: string;
   storeAddress: string;
   imageUrls: string[];
-  userPreferences: string[];
+  userPreferences: number[];
 }
 
 export interface DeleteSavedListRequest {

--- a/packages/infrastructures/src/repositories/storeAPIRepository.ts
+++ b/packages/infrastructures/src/repositories/storeAPIRepository.ts
@@ -1,4 +1,5 @@
 import APIRepository from './apiRepository';
+import PreferenceConverter from '../mappers/preferenceConverter';
 import type {
   StoreRepository,
   StoreSummaryInfoData,
@@ -46,6 +47,8 @@ import type {
 import type { BaseRequestData } from '@repo/entity/src/appMetadata';
 import fetch from '@repo/api/src/fetch';
 
+const preferenceConverter = new PreferenceConverter();
+
 export default class StoreAPIRepository
   extends APIRepository
   implements StoreRepository
@@ -68,12 +71,16 @@ export default class StoreAPIRepository
       throw Error('data required');
     }
 
-    const { latitude, longitude, radius, preferenceTagIds, searchKeyword } =
+    const { latitude, longitude, radius, preferenceTagNames, searchKeyword } =
       data || {};
 
     let url = `${this.endpoint}/stores/map?latitude=${latitude}&longitude=${longitude}&radius=${radius}`;
 
-    if (preferenceTagIds && preferenceTagIds.length > 0) {
+    if (preferenceTagNames && preferenceTagNames.length > 0) {
+      const preferenceTagIds =
+        preferenceConverter.convertPreferenceToRaw(preferenceTagNames);
+
+      console.log(preferenceTagIds);
       url += `&preferenceTagIds=${preferenceTagIds.join(',')}`;
     }
 
@@ -125,7 +132,10 @@ export default class StoreAPIRepository
       throw Error('data required');
     }
 
-    const { latitude, longitude, radius, preferenceTagId } = data || {};
+    const { latitude, longitude, radius, preferenceTagNames } = data || {};
+
+    const preferenceTagIds =
+      preferenceConverter.convertPreferenceToRaw(preferenceTagNames);
 
     const response = await fetch<void, NearByStoreData[]>({
       ...(authorization && {
@@ -135,7 +145,7 @@ export default class StoreAPIRepository
         },
       }),
       method: 'GET',
-      url: `${this.endpoint}/stores/map?latitude=${latitude}&longitude=${longitude}&radius=${radius}&preference=${preferenceTagId}`,
+      url: `${this.endpoint}/stores/map?latitude=${latitude}&longitude=${longitude}&radius=${radius}&preference=${preferenceTagIds}`,
     });
 
     return response;

--- a/packages/infrastructures/src/repositories/storeAPIRepository.ts
+++ b/packages/infrastructures/src/repositories/storeAPIRepository.ts
@@ -47,12 +47,12 @@ import type {
 import type { BaseRequestData } from '@repo/entity/src/appMetadata';
 import fetch from '@repo/api/src/fetch';
 
-const preferenceConverter = new PreferenceConverter();
-
 export default class StoreAPIRepository
   extends APIRepository
   implements StoreRepository
 {
+  private readonly preferenceConverter = new PreferenceConverter();
+
   //preference
   async getAllPreference(): Promise<PreferenceData[]> {
     const response = await fetch<void, PreferenceData[]>({
@@ -78,7 +78,7 @@ export default class StoreAPIRepository
 
     if (preferenceTagNames && preferenceTagNames.length > 0) {
       const preferenceTagIds =
-        preferenceConverter.convertPreferenceToRaw(preferenceTagNames);
+        this.preferenceConverter.convertPreferenceToRaw(preferenceTagNames);
 
       url += `&preferenceTagIds=${preferenceTagIds.join(',')}`;
     }
@@ -134,7 +134,7 @@ export default class StoreAPIRepository
     const { latitude, longitude, radius, preferenceTagNames } = data || {};
 
     const preferenceTagIds =
-      preferenceConverter.convertPreferenceToRaw(preferenceTagNames);
+      this.preferenceConverter.convertPreferenceToRaw(preferenceTagNames);
 
     const response = await fetch<void, NearByStoreData[]>({
       ...(authorization && {
@@ -386,7 +386,7 @@ export default class StoreAPIRepository
     const { listId, storeUuid, userPreferences } = data || {};
 
     const preferenceTagIds =
-      preferenceConverter.convertPreferenceToRaw(userPreferences);
+      this.preferenceConverter.convertPreferenceToRaw(userPreferences);
 
     const url = `${this.endpoint}/user-store/lists/${listId}/stores/${storeUuid}`;
 

--- a/packages/infrastructures/src/repositories/storeAPIRepository.ts
+++ b/packages/infrastructures/src/repositories/storeAPIRepository.ts
@@ -357,7 +357,6 @@ export default class StoreAPIRepository
       ...(authorization && {
         headers: {
           Authorization: authorization,
-          'Content-Type': 'multipart/form-data',
         },
       }),
       method: 'DELETE',

--- a/packages/infrastructures/src/repositories/storeAPIRepository.ts
+++ b/packages/infrastructures/src/repositories/storeAPIRepository.ts
@@ -80,7 +80,6 @@ export default class StoreAPIRepository
       const preferenceTagIds =
         preferenceConverter.convertPreferenceToRaw(preferenceTagNames);
 
-      console.log(preferenceTagIds);
       url += `&preferenceTagIds=${preferenceTagIds.join(',')}`;
     }
 

--- a/packages/infrastructures/src/repositories/storeAPIRepository.ts
+++ b/packages/infrastructures/src/repositories/storeAPIRepository.ts
@@ -386,18 +386,18 @@ export default class StoreAPIRepository
 
     const { listId, storeUuid, userPreferences } = data || {};
 
+    const preferenceTagIds =
+      preferenceConverter.convertPreferenceToRaw(userPreferences);
+
     const url = `${this.endpoint}/user-store/lists/${listId}/stores/${storeUuid}`;
 
-    const response = await fetch<
-      typeof userPreferences,
-      AddStoreInSavedListResponse
-    >({
+    const response = await fetch<number[], AddStoreInSavedListResponse>({
       ...(authorization && {
         headers: {
           Authorization: authorization,
         },
       }),
-      data: userPreferences,
+      data: preferenceTagIds,
       method: 'POST',
       url,
     });

--- a/packages/usecase/src/storeService.ts
+++ b/packages/usecase/src/storeService.ts
@@ -1,4 +1,5 @@
 import type { AuthRepository } from '@repo/entity/src/auth';
+import type { Preference } from '@repo/entity/src/preference';
 import type {
   StoreDetailInfoData,
   NearByStoreData,
@@ -66,13 +67,13 @@ export default class StoreService {
     latitude,
     longitude,
     radius,
-    preferenceTagIds,
+    preferenceTagNames,
     searchKeyword,
   }: {
     latitude: number;
     longitude: number;
     radius: number;
-    preferenceTagIds?: number[];
+    preferenceTagNames?: Preference[];
     searchKeyword?: string;
   }): Promise<NearByStoreData[]> {
     try {
@@ -89,7 +90,7 @@ export default class StoreService {
           latitude,
           longitude,
           radius,
-          preferenceTagIds,
+          preferenceTagNames,
           searchKeyword,
         },
         ...(authorization && { authorization }),


### PR DESCRIPTION
### Summary
- 처음 getAllPreference 불러온 카테고리 응답 데이터는 변환하지 않고 그대로 사용
- useTag에서 태그 선택시 tagId가 아니라 tagName을 저장하도록 함(여기서 태그 선택여부, 선택된 태그 Set, 배열 관리)
- 프론트에선 tagName만 사용됨
- 그대로 api까지 Preference 타입인 tagName 배열을 보냄
- api에서 서버로 보내는 요청 데이터를 preferenceConverter를 사용해서 모두 tagId로 변환하여 전송
- 가게 담기 시에도 똑같이 user 객체에 담긴 Preference 배열을 api까지 보내고 api에서 id로 변환하여 전송

(kakaoMap 컴포넌트는 건드린게 별로없는데 왜 이렇게 많이 바뀌어있는지 모르겠네요..)